### PR TITLE
Add ProductSpec, DesignSpec, DataModel, and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,58 @@
+# MicroMoment
+
+A focused habit tracker built around the "5 minutes a day" philosophy. Hard cap of 5 active habits, durations of 1–5 minutes each, single daily check-in. Local-first (SQLite on-device, no account, no sync).
+
+## Documentation
+
+- [`docs/ProductSpec.md`](docs/ProductSpec.md) — purpose, features, user flows, acceptance criteria
+- [`docs/DesignSpec.md`](docs/DesignSpec.md) — design tokens, components, screens, motion
+- [`docs/DataModel.md`](docs/DataModel.md) — DB schema, store, notifications
+
+## Tech stack
+
+- **Framework**: Expo SDK 55 / React Native 0.83 / React 19
+- **Routing**: expo-router (typed routes, stack + tabs)
+- **State**: Zustand
+- **Database**: expo-sqlite (WAL, FK on)
+- **Notifications**: expo-notifications (per-habit daily, Android channel)
+- **Animation**: Reanimated 4, gesture-handler, draggable-flatlist, confetti-cannon
+- **Analytics**: Sentry, PostHog (optional)
+- **Tests**: Jest unit tests, YAML-based E2E scenarios
+- **Build**: EAS
+
+Targets iOS 16+ and Android API 26+. Portrait only. Phone only.
+
+## Getting started
+
+```bash
+npm install
+npx expo start
+```
+
+Run on a device/simulator from the Expo CLI menu. For native builds use `eas build` (see `eas.json`).
+
+## Project layout
+
+```
+app/             expo-router screens
+components/      reusable UI (Button, HabitCard, CheckButton, …)
+constants/       colors, typography, daily messages
+db/              SQLite schema + queries
+store/           Zustand stores
+hooks/           shared hooks
+utils/           streak calc, notifications, helpers
+__tests__/       Jest unit tests
+e2e/             YAML E2E scenarios + run_all.sh
+```
+
+## Scripts
+
+See `package.json` for the full list. Common ones:
+
+- `npm test` — run Jest
+- `npx expo start` — dev server
+- `eas build` — native build via EAS
+
+## Contributing
+
+When changing user-facing behavior, update the relevant doc under `docs/` in the same PR.

--- a/docs/DataModel.md
+++ b/docs/DataModel.md
@@ -1,0 +1,107 @@
+# MicroMoment — Data Model
+
+## 1. Storage
+
+- **Primary store**: SQLite via `expo-sqlite`, database file `micromoment.db`. WAL mode, foreign keys enabled.
+- **Secondary store**: AsyncStorage for the `onboarding_complete` flag only.
+- **No remote storage.** All data is on-device.
+
+## 2. Schema (`db/schema.ts`)
+
+### 2.1 `habits`
+
+| Column | Type | Constraints |
+|---|---|---|
+| id | TEXT | PRIMARY KEY |
+| name | TEXT | NOT NULL |
+| emoji | TEXT | NOT NULL |
+| time_estimate_min | INTEGER | NOT NULL, CHECK 1–5 |
+| time_of_day | TEXT | NOT NULL, CHECK in ('morning','afternoon','evening') |
+| sort_order | INTEGER | NOT NULL |
+| is_active | INTEGER | NOT NULL DEFAULT 1 |
+| created_at | TEXT | NOT NULL (ISO 8601) |
+| reminder_time | TEXT | nullable, HH:MM |
+| reminder_offset_min | INTEGER | nullable, minutes before `reminder_time` |
+
+### 2.2 `completions`
+
+| Column | Type | Constraints |
+|---|---|---|
+| id | TEXT | PRIMARY KEY |
+| habit_id | TEXT | NOT NULL, FK → habits(id) ON DELETE CASCADE |
+| completed_date | TEXT | NOT NULL, YYYY-MM-DD (local date) |
+| completed_at | TEXT | NOT NULL (ISO 8601) |
+| note | TEXT | nullable |
+| grace_used | INTEGER | NOT NULL DEFAULT 0 |
+
+### 2.3 Indices
+
+- `idx_habits_active` on `habits(is_active)`
+- `idx_completions_habit_id` on `completions(habit_id)`
+- `idx_completions_date` on `completions(completed_date)`
+
+### 2.4 Invariants
+
+- `is_active = 1` count never exceeds **5** (enforced in store layer, not DB).
+- One completion per `(habit_id, completed_date)` is the intended invariant. Enforced at the store layer via `markComplete()` guard; not via DB unique constraint.
+- Deleting a habit cascades its completions. Archiving does not delete completions (history is preserved).
+
+## 3. Application state (`store/habitStore.ts`)
+
+Zustand store. Single source of truth for the UI; mirrors a subset of DB state.
+
+### 3.1 State
+
+| Field | Type | Purpose |
+|---|---|---|
+| habits | `Habit[]` | active habits sorted by `sort_order` |
+| todayCompletions | `Completion[]` | completions where `completed_date = today` |
+| streaks | `Record<string, number>` | current streak per `habit.id` |
+| isLoading | `boolean` | hydration / mutation flag |
+
+### 3.2 Actions
+
+| Action | Effect |
+|---|---|
+| `loadHabits()` | SELECT active habits ordered by `sort_order` |
+| `loadTodayCompletions()` | SELECT completions for today |
+| `loadStreaks()` | Compute `calculateStreak()` for each habit |
+| `getHabitStreak(id)` | Read from `streaks` |
+| `createHabit(input)` | Validate (cap, duration, name); INSERT; schedule notification |
+| `updateHabit(id, input)` | Partial UPDATE; reschedule notification |
+| `deleteHabit(id)` | DELETE habit (cascade); cancel notification |
+| `archiveHabit(id)` | UPDATE `is_active = 0`; cancel notification |
+| `restoreHabit(id)` | UPDATE `is_active = 1` (cap check); reschedule notification |
+| `reorderHabits(ids)` | UPDATE `sort_order` in transaction |
+| `markComplete(id, note?)` | INSERT completion for today (idempotent guard) |
+| `getArchivedHabits()` | SELECT inactive habits ordered by `created_at DESC` |
+
+### 3.3 Constants
+
+- `MAX_HABITS = 5`
+
+## 4. Derived calculations (`utils/streakCalculator.ts`)
+
+- **Current streak**: count of consecutive calendar days, ending today or yesterday, on which the habit has at least one completion. Streak does not break until a day is fully missed (i.e., today not yet completed does not zero the streak if yesterday was).
+- **Longest streak**: max consecutive run across all completions (used in Progress).
+- **Milestones**: streak values in `{7, 14, 21, 30, 60, 90, 180, 365}` trigger UI confetti and analytics.
+
+## 5. Notification linkage (`utils/notifications.ts`)
+
+- Each habit with `reminder_time` set has a daily local notification scheduled with identifier `habit-reminder-{id}`.
+- Effective fire time = `reminder_time` minus `reminder_offset_min` minutes (in local timezone).
+- On every app start, `_layout.tsx` calls `rescheduleAllNotifications(habits)` which cancels all and re-schedules each active habit.
+- Android requires the `habit-reminders` channel (HIGH importance, default sound, vibration `[0,250,250,250]`); created at app init.
+
+## 6. Lifecycle summary
+
+| Event | DB writes | Notification action |
+|---|---|---|
+| Create habit | INSERT habits | schedule (if reminder set) |
+| Update habit | UPDATE habits | cancel + schedule |
+| Mark complete | INSERT completions | none |
+| Archive | UPDATE habits.is_active=0 | cancel |
+| Restore | UPDATE habits.is_active=1 | schedule (if reminder set) |
+| Delete | DELETE habits (cascade) | cancel |
+| Reorder | UPDATE habits.sort_order | none |
+| App start | none | reschedule all active |

--- a/docs/DesignSpec.md
+++ b/docs/DesignSpec.md
@@ -1,0 +1,152 @@
+# MicroMoment — Design Specification
+
+## 1. Design tokens
+
+### 1.1 Colors (`constants/colors.ts`)
+
+**Light**
+| Token | Hex |
+|---|---|
+| background | #F8F8F6 |
+| surface | #FFFFFF |
+| text | #1A1A1A |
+| textSecondary | #6B6B6B |
+| primary | #34A853 |
+| primaryLight | #A8D5A2 |
+| border | #E5E5E5 |
+| cardBackground | #FFFFFF |
+| completedCard | #F0F0F0 |
+| completedText | #AAAAAA |
+| streak | #FF9F0A |
+| danger | #FF3B30 |
+| sectionHeader | #9E9E9E |
+| checkActive | #34A853 |
+| checkInactive | #E5E5E5 |
+| ringBackground | #E5E5E5 |
+| ringFill | #34A853 |
+
+**Dark** — same semantic tokens with adjusted values (background #121212, surface #1E1E1E, text #F5F5F5, textSecondary #A0A0A0, primaryLight #1E6E36, border #2C2C2C, etc.). Primary green (#34A853) and danger red (#FF3B30) are shared.
+
+**Heatmap scale (0–4)**: blue gradient from #F0F4FF (empty) to #0A84FF (full).
+
+### 1.2 Typography (`constants/typography.ts`)
+
+| Style | Size | Weight | Tracking |
+|---|---|---|---|
+| title | 28 | 700 | -0.5 |
+| body | 16 | 500 | — |
+| secondary | 14 | 400 | — |
+| label | 12 | 600 | 0.5 |
+| caption | 11 | 500 | — |
+
+System font (no custom font loading).
+
+### 1.3 Spacing
+
+- Screen horizontal padding: 20
+- Card padding: 14–16
+- Section gaps: 8 / 12 / 20 / 28
+
+### 1.4 Elevation
+
+Card shadow (iOS): offset (0, 1), opacity 0.06, radius 4. Android `elevation: 2`.
+
+### 1.5 Radii
+
+- Cards: 14
+- Buttons: 14
+- Pills (time-of-day, offset): pill / fully rounded
+
+## 2. Component system
+
+### 2.1 Button (`components/Button.tsx`)
+Variants: **primary**, **secondary**, **danger**, **ghost**. Height 56 (ghost overrides padding to 8 vertical). Border radius 14. Disabled state opacity 0.45. Optional inline loading spinner. All variants wrap `AnimatedPressable`.
+
+### 2.2 AnimatedPressable
+Scale-to-0.96 on press-in, spring back on release. Optional `Haptics.Light` impact. Skips animation and haptic when `AccessibilityInfo.isReduceMotionEnabled()` is true.
+
+### 2.3 HabitCard
+Row with emoji, name, meta (duration · time-of-day), 🔥 streak badge (when ≥ 2), drag handle (⋮⋮), and CheckButton. Wrapped in `Swipeable`; right actions reveal Edit (green) and Delete (red). Long-press (400ms) opens swipe menu. When completed today: opacity 0.45 and `completedText` color.
+
+### 2.4 CheckButton
+Circle 40×40. Inactive border (`checkInactive`), active fill (`checkActive`) with white ✓. Spring scale 1 → 1.3 → 1 on tap; haptic.
+
+### 2.5 CompletionRing
+SVG ring; background (`ringBackground`) + animated foreground stroke (`ringFill`) driven by Reanimated. Centered numeric counter.
+
+### 2.6 DailyMessage
+Single-line text component reading from the 321-message pool indexed by day-of-year.
+
+### 2.7 EmojiPicker
+Grid of 40 curated emoji. Selected emoji has primary border/background.
+
+### 2.8 ReminderModal
+Bottom-style modal with hour/minute incrementers and a row of offset pills (At time / 15 min / 30 min / 1 hr / 2 hrs before). Cancel / Set actions.
+
+## 3. Screens
+
+### 3.1 Onboarding (`app/onboarding.tsx`)
+Full-screen primary-green background. Horizontal `FlatList` (scrollEnabled: false). 3 slides with title + subtitle. Bottom: dot indicators + Next button (becomes "Get Started" on last slide). Skip button top-right.
+
+### 3.2 Today (`app/(tabs)/index.tsx`)
+- Header: date string + DailyMessage.
+- Body: `DraggableFlatList` of HabitCards.
+- Footer / inline: drag hint (≥ 2 habits), 5-habit cap banner (when at cap).
+- Empty state: friendly prompt + add CTA.
+- FAB-style "+" in header right; disabled at cap.
+- Confetti overlay on milestone streak completion.
+
+### 3.3 Progress (`app/(tabs)/progress.tsx`)
+- Last 7 days summary card: dot strip + count.
+- Per-habit stats: emoji, name, current streak, longest streak, total completions.
+- 8-week heatmap: 8 rows × 7 cols (Mon-anchored). Week labels (e.g. "Jan 15") left-aligned.
+
+### 3.4 Settings (`app/(tabs)/settings.tsx`)
+- Archived Habits section: rows with emoji + name + Restore.
+- About section: version, Reset Onboarding action.
+
+### 3.5 New Habit (`app/habit/new.tsx`)
+Modal. Fields top-to-bottom: EmojiPicker, name TextInput, time-of-day pills, duration stepper (−/+ around minute count), Reminder row (opens ReminderModal). Header: Close (left), Save (right; "Saving…" while loading). `KeyboardAvoidingView` on iOS.
+
+### 3.6 Habit Detail / Edit (`app/habit/[id].tsx`)
+- View mode: hero emoji, name, meta, "Mark Complete" primary button. Header Edit button.
+- Edit mode (`?mode=edit` or via Edit button): same form as New Habit + danger zone (Archive, Delete with confirmation alerts). Header Save / Cancel.
+- Falls back to "not found" state if habit was deleted while open.
+
+## 4. Navigation
+
+- Root stack (`app/_layout.tsx`): `(tabs)`, `onboarding` (modal, no swipe-down), `habit/[id]` (card), `habit/new` (modal). Headers hidden globally.
+- Tabs (`app/(tabs)/_layout.tsx`): three bottom tabs — Today (✓), Progress (▦), Settings (⚙). Active tint = primary; inactive = textSecondary.
+- Onboarding gate: `_layout.tsx` reads `onboarding_complete` and routes to `/onboarding` if absent.
+
+## 5. Interaction patterns
+
+| Pattern | Where | Behavior |
+|---|---|---|
+| Tap | Buttons, check, list rows | scale 0.96 + haptic |
+| Long-press | HabitCard | 400ms → opens swipe actions |
+| Swipe left | HabitCard | reveals Edit / Delete |
+| Drag (long-press handle) | HabitCard | reorders, persists `sort_order` |
+| Pull-to-refresh | none | not implemented |
+| Confetti | milestone completion | 120 particles, 3000ms fall, top-center origin |
+| Disabled state | over-cap, in-flight save | opacity 0.45, no haptic |
+
+## 6. Accessibility
+
+- Reduce-motion respected: animations and haptics gated by `AccessibilityInfo.isReduceMotionEnabled()`.
+- Color contrast: text/textSecondary against background/surface meet WCAG AA in both themes.
+- Tap targets ≥ 40×40 (CheckButton, tab icons, drag handle).
+- Touchables expose accessible labels (habit name, action verbs).
+
+## 7. Iconography
+
+- Tab icons: emoji glyphs (✓ ▦ ⚙).
+- In-content icons: `@expo/vector-icons` Ionicons (drag handle, settings rows).
+- Emoji as primary "icon" language for habits — chosen by user from 40-emoji palette.
+
+## 8. Motion
+
+- Reanimated 4 spring physics for press feedback and CheckButton scale.
+- CompletionRing stroke animates linearly to target progress.
+- Confetti via `react-native-confetti-cannon`.
+- All motion bypassed under reduce-motion.

--- a/docs/ProductSpec.md
+++ b/docs/ProductSpec.md
@@ -1,0 +1,102 @@
+# MicroMoment — Product Specification
+
+## 1. Purpose
+
+MicroMoment is a habit-tracking app built around the "5 minutes a day" philosophy: tiny daily actions that compound. The app deliberately constrains scope to keep users focused — a hard cap of 5 active habits, durations of 1–5 minutes each, and a single daily check-in per habit.
+
+## 2. Target user
+
+Individuals who want to build sustainable daily routines without the friction or sprawl of generic habit trackers. The product opinion is that *fewer habits, completed consistently* outperform long lists that are abandoned.
+
+## 3. Core principles
+
+- **Constraint over flexibility.** 5 habits max. 1–5 minute durations. One completion per habit per day.
+- **Local-first.** All data lives on-device in SQLite. No account, no cloud sync.
+- **Encouragement over guilt.** Streaks and milestone confetti reward consistency; there is no "failure" UI.
+- **Calm UI.** Light/dark themes, subtle animation, haptics that respect reduce-motion.
+
+## 4. Feature list
+
+### 4.1 Onboarding
+A 3-slide manual-paginated intro shown on first launch:
+1. "Five minutes/day"
+2. "5 habits max"
+3. "Streaks & milestones"
+Skippable. Completion writes `onboarding_complete` to AsyncStorage and emits an `onboarding_completed` analytics event. Resettable from Settings.
+
+### 4.2 Habit CRUD
+- **Create** (`/habit/new`): emoji (40-emoji palette), name (1–50 chars), time-of-day (morning/afternoon/evening), duration (1–5 min stepper), optional reminder.
+- **Read**: Today tab list, detail screen, archived list in Settings.
+- **Update** (`/habit/[id]`): same form as create, plus danger zone.
+- **Delete**: hard delete with confirmation; cascades to completions.
+- **Archive / Restore**: soft delete (`is_active = 0`); restore subject to 5-habit cap.
+- **Hard cap**: 5 active habits. Add button disabled at cap; banner displayed.
+
+### 4.3 Daily check-in
+Circular check button on each habit card on the Today tab. Single tap marks complete for the current local date. Spring scale animation, haptic feedback, checkmark glyph. Double-completion is silently prevented.
+
+### 4.4 Streaks & milestones
+Current streak (consecutive completion days) shown as 🔥 N badge on cards when ≥ 2. Milestone streaks (7, 14, 21, 30, 60, 90, 180, 365) trigger a confetti animation and emit a `streak_milestone` analytics event.
+
+### 4.5 Drag-to-reorder
+Long-press a habit card or use the ⋮⋮ drag handle to reorder on the Today tab. Persists to `sort_order`. Hint text shown when ≥ 2 habits.
+
+### 4.6 Swipe & long-press menu
+Swipe left on a habit card to reveal Edit (green) and Delete (red) actions. Long-press (400ms) opens the same menu without dragging.
+
+### 4.7 Progress
+Progress tab shows:
+- Last 7 days summary (dot strip + count).
+- Per-habit stats: current streak, longest streak, total completions.
+- 8-week heatmap grid (56 days, snapped to Monday). Cells colored 0–4 by daily completion ratio. Week labels on the left.
+
+### 4.8 Per-habit reminders
+Optional daily local notification per habit. Configurable time (HH:MM) and offset (0 / 15 / 30 / 60 / 120 min before). Notifications are rescheduled on every app start. Android uses the `habit-reminders` channel with HIGH importance.
+
+### 4.9 Daily motivational message
+A rotating message from a 321-entry pool, selected by day-of-year, displayed on the Today tab.
+
+### 4.10 Dark mode
+Full light/dark theme support driven by system `useColorScheme()`.
+
+### 4.11 Settings
+- Archived Habits list with one-tap restore.
+- About: app version (from `expo-application`), reset onboarding action.
+
+## 5. User flows
+
+### 5.1 First launch
+App launch → check `onboarding_complete` → if absent, push `/onboarding` modal → user completes or skips → flag set → land on Today tab (empty state).
+
+### 5.2 Add first habit
+Today tab → tap "+" → `/habit/new` modal → pick emoji, name, time-of-day, duration, optional reminder → Save → modal dismisses → habit appears on Today tab.
+
+### 5.3 Daily check-in
+Today tab → tap check button on a habit → animation + haptic → completion recorded for today → streak updates → if milestone, confetti.
+
+### 5.4 Edit a habit
+Today tab → long-press or swipe-left a card → tap Edit → `/habit/[id]?mode=edit` → modify fields → Save.
+
+### 5.5 Archive / Restore
+Detail screen → Danger zone → Archive (with confirmation) → habit removed from Today, notification cancelled. Settings → Archived → Restore → habit returns (if under 5-habit cap).
+
+### 5.6 Set a reminder
+New / Edit habit → tap Reminder row → modal with hour/minute incrementers + offset pills → Set → schedule registered with Expo Notifications.
+
+## 6. Acceptance criteria
+
+- A user can create a habit and see it on the Today tab in under 30 seconds.
+- The app refuses to create or restore a 6th active habit.
+- Completing a habit immediately reflects in the streak count and progress heatmap.
+- Reminders fire at the configured local time, accounting for the offset, every day.
+- Deleting a habit also removes its completions (FK cascade).
+- All habit / completion data persists across app restarts and survives device reboot.
+- Light and dark themes render every screen without unreadable contrast.
+- No screen requires network connectivity to function.
+
+## 7. Non-goals
+
+- Multi-device sync, accounts, social features.
+- Habits longer than 5 minutes or more than 5 active habits.
+- Multiple completions per habit per day.
+- Web or tablet layouts.


### PR DESCRIPTION
## Summary
- Adds `docs/ProductSpec.md`, `docs/DesignSpec.md`, `docs/DataModel.md` reverse-engineered from current codebase
- Adds top-level `README.md` linking to the specs
- Closes #49

## Test plan
- [ ] Skim each doc against current `app/`, `components/`, `store/`, `db/`, `utils/notifications.ts`
- [ ] Confirm 5-habit cap, milestone list, reminder offset values, and heatmap geometry match code