### PR TITLE
Atomic markComplete + CheckButton 44×44

### DIFF
--- a/__tests__/db/completions.test.ts
+++ b/__tests__/db/completions.test.ts
@@ -35,7 +35,7 @@ describe('insertCompletion', () => {
   it('inserts with correct fields and returns completion object', async () => {
     const result = await insertCompletion({ habit_id: 'habit-1' })
     expect(mockDb.runAsync).toHaveBeenCalledWith(
-      expect.stringContaining('INSERT INTO completions'),
+      expect.stringContaining('INSERT OR IGNORE INTO completions'),
       expect.arrayContaining(['test-uuid-1234-5678-abcd', 'habit-1', TODAY_STR])
     )
     expect(result.habit_id).toBe('habit-1')

--- a/__tests__/db/schema.test.ts
+++ b/__tests__/db/schema.test.ts
@@ -23,10 +23,17 @@ beforeEach(() => {
 describe('initialiseDatabase', () => {
   it('executes CREATE TABLE statements without error', async () => {
     await initialiseDatabase(mockDb as any)
-    expect(mockDb.execAsync).toHaveBeenCalledTimes(1)
+    expect(mockDb.execAsync).toHaveBeenCalled()
     const sql = mockDb.execAsync.mock.calls[0][0] as string
     expect(sql).toContain('CREATE TABLE IF NOT EXISTS habits')
     expect(sql).toContain('CREATE TABLE IF NOT EXISTS completions')
+  })
+
+  it('enforces one completion per habit per day via UNIQUE index', async () => {
+    await initialiseDatabase(mockDb as any)
+    const allSql = mockDb.execAsync.mock.calls.map((c: unknown[]) => c[0] as string).join('\n')
+    expect(allSql).toContain('CREATE UNIQUE INDEX IF NOT EXISTS uniq_completions_habit_date')
+    expect(allSql).toContain('ON completions(habit_id, completed_date)')
   })
 
   it('enables WAL journal mode and foreign keys', async () => {

--- a/components/CheckButton.tsx
+++ b/components/CheckButton.tsx
@@ -16,7 +16,7 @@ interface CheckButtonProps {
   size?: number
 }
 
-export function CheckButton({ completed, onPress, size = 36 }: CheckButtonProps) {
+export function CheckButton({ completed, onPress, size = 44 }: CheckButtonProps) {
   const colors = useThemeColors()
   const scale = useSharedValue(1)
 

--- a/db/completions.ts
+++ b/db/completions.ts
@@ -29,11 +29,21 @@ export async function insertCompletion(input: InsertCompletionInput): Promise<Co
   const grace_used = input.grace_used ? 1 : 0
   const note = input.note ?? null
 
-  await db.runAsync(
-    `INSERT INTO completions (id, habit_id, completed_date, completed_at, note, grace_used)
+  // INSERT OR IGNORE atomically enforces the (habit_id, completed_date) UNIQUE index.
+  // On conflict, return the existing row instead of fabricating a new one.
+  const result = await db.runAsync(
+    `INSERT OR IGNORE INTO completions (id, habit_id, completed_date, completed_at, note, grace_used)
      VALUES (?, ?, ?, ?, ?, ?)`,
     [id, input.habit_id, completed_date, completed_at, note, grace_used]
   )
+
+  if (result.changes === 0) {
+    const existing = await db.getFirstAsync<Completion>(
+      'SELECT * FROM completions WHERE habit_id = ? AND completed_date = ?',
+      [input.habit_id, completed_date]
+    )
+    if (existing) return existing
+  }
 
   return { id, habit_id: input.habit_id, completed_date, completed_at, note, grace_used }
 }

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -42,6 +42,16 @@ export async function initialiseDatabase(database: SQLite.SQLiteDatabase): Promi
   // Per-habit reminder columns — added after initial release, safe to run repeatedly
   try { await database.execAsync('ALTER TABLE habits ADD COLUMN reminder_time TEXT') } catch {}
   try { await database.execAsync('ALTER TABLE habits ADD COLUMN reminder_offset_min INTEGER') } catch {}
+
+  // One completion per (habit, day). Pre-dedupe so the UNIQUE index can be added to legacy DBs.
+  await database.execAsync(`
+    DELETE FROM completions
+    WHERE rowid NOT IN (
+      SELECT MIN(rowid) FROM completions GROUP BY habit_id, completed_date
+    );
+    CREATE UNIQUE INDEX IF NOT EXISTS uniq_completions_habit_date
+      ON completions(habit_id, completed_date);
+  `)
 }
 
 export function closeDatabase(): void {


### PR DESCRIPTION
Rebased clean against current main (the original PR #60 had merge conflicts after #50 and #55 landed).

## Summary
- DB UNIQUE on \`completions(habit_id, completed_date)\` + \`INSERT OR IGNORE\` makes \`markComplete\` race-free (closes #59)
- \`CheckButton\` default size 36 → 44 to meet Apple HIG and DesignSpec a11y minimum (closes #56)
- Pre-dedupes legacy completion rows so the migration is safe on existing installs
- Tests + tsc clean