### PR TITLE
Fix drift D6/D7/D8 (HabitCard meta, Reduce Motion, message count)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ google-service-account.json
 
 # test coverage
 coverage/
+
+# Claude Code user-local config
+.claude/

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -20,6 +20,7 @@ import { CompletionRing } from '../../components/CompletionRing'
 import { HabitCard } from '../../components/HabitCard'
 import { DailyMessage } from '../../components/DailyMessage'
 import { useThemeColors } from '../../hooks/useThemeColors'
+import { useReduceMotion } from '../../hooks/useReduceMotion'
 import { AnimatedPressable } from '../../components/AnimatedPressable'
 import { trackHabitCompleted, trackStreakMilestone } from '../../utils/analytics'
 import type { Habit } from '../../db/habits'
@@ -36,6 +37,7 @@ function formatDate(date: Date): string {
 
 export default function HomeScreen() {
   const colors = useThemeColors()
+  const reduceMotion = useReduceMotion()
   const router = useRouter()
   const confettiRef = useRef<ConfettiCannon>(null)
   const {
@@ -68,7 +70,7 @@ export default function HomeScreen() {
       const newStreak = await getHabitStreak(habitId)
       trackHabitCompleted(habitId, newStreak)
       if (MILESTONE_STREAKS.has(newStreak)) {
-        confettiRef.current?.start()
+        if (!reduceMotion) confettiRef.current?.start()
         trackStreakMilestone(habitId, newStreak)
       }
       loadStreaks()

--- a/components/CheckButton.tsx
+++ b/components/CheckButton.tsx
@@ -9,6 +9,7 @@ import Animated, {
 } from 'react-native-reanimated'
 import * as Haptics from 'expo-haptics'
 import { useThemeColors } from '../hooks/useThemeColors'
+import { useReduceMotion } from '../hooks/useReduceMotion'
 
 interface CheckButtonProps {
   completed: boolean
@@ -18,6 +19,7 @@ interface CheckButtonProps {
 
 export function CheckButton({ completed, onPress, size = 44 }: CheckButtonProps) {
   const colors = useThemeColors()
+  const reduceMotion = useReduceMotion()
   const scale = useSharedValue(1)
 
   const animatedStyle = useAnimatedStyle(() => ({
@@ -27,15 +29,12 @@ export function CheckButton({ completed, onPress, size = 44 }: CheckButtonProps)
   const handlePress = () => {
     if (completed) return
 
-    scale.value = withSpring(1.3, { damping: 6 }, () => {
-      scale.value = withSpring(1)
-    })
-
-    AccessibilityInfo.isReduceMotionEnabled().then((reduced) => {
-      if (!reduced) {
-        Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light)
-      }
-    })
+    if (!reduceMotion) {
+      scale.value = withSpring(1.3, { damping: 6 }, () => {
+        scale.value = withSpring(1)
+      })
+      Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light)
+    }
 
     runOnJS(onPress)()
   }

--- a/components/HabitCard.tsx
+++ b/components/HabitCard.tsx
@@ -12,6 +12,12 @@ import { CheckButton } from './CheckButton'
 import { useThemeColors } from '../hooks/useThemeColors'
 import type { Habit } from '../db/habits'
 
+const TIME_OF_DAY_META = {
+  morning: '🌅 Morning',
+  afternoon: '☀️ Afternoon',
+  evening: '🌙 Evening',
+} as const
+
 interface HabitCardProps {
   habit: Habit
   completed: boolean
@@ -112,7 +118,7 @@ export function HabitCard({ habit, completed, streak, onComplete, onEdit, onDele
               </Text>
               <View style={styles.meta}>
                 <Text style={[styles.duration, { color: colors.textSecondary }]}>
-                  {habit.time_estimate_min} min
+                  {habit.time_estimate_min} min · {TIME_OF_DAY_META[habit.time_of_day as keyof typeof TIME_OF_DAY_META]}
                 </Text>
                 {streak !== undefined && streak >= 2 && (
                   <View style={[styles.streakBadge, { backgroundColor: colors.streak + '20' }]}>

--- a/constants/messages.ts
+++ b/constants/messages.ts
@@ -318,6 +318,8 @@ export const DAILY_MESSAGES: string[] = [
   "Future you is grateful for present you.",
   "Excellence is a habit, not an event.",
   "You made the time. That's everything.",
+  "Showing up is the whole strategy.",
+  "Steady wins. Always.",
 ]
 
 function getDayOfYear(date: Date): number {

--- a/docs/test-reports/.flint-state.json
+++ b/docs/test-reports/.flint-state.json
@@ -1,0 +1,151 @@
+{
+  "phase": "post-spec-baseline",
+  "run": 7,
+  "branch": "main",
+  "date": "2026-05-02",
+  "phase_completed": ["plan", "execute"],
+  "regression_count": {
+    "P0": 12,
+    "P1": 20,
+    "P2": 5,
+    "total": 37
+  },
+  "uat_count": {
+    "authored": 30,
+    "to_author": 0,
+    "planned": 30,
+    "total": 30,
+    "added_in_validation": ["UAT-25", "UAT-26", "UAT-27", "UAT-28", "UAT-29", "UAT-30"]
+  },
+  "uat_validation": {
+    "validated_at": "2026-05-02T00:00:00Z",
+    "validator": "Flint (iOS QA)",
+    "method_notes": "Four-check pass: structural verdicts per scenario; code-grounded mechanical check against app/, components/, db/schema.ts, AsyncStorage usage; independent cross-check vs spec; drift escalation.",
+    "structural": {
+      "_legend": {
+        "q1_given_when_then": "Scenario is in Given/When/Then form with a clear user story header",
+        "q2_deterministic_precondition": "Given clause specifies a concrete observable state (storage flag, DB row, count, mode) - not 'if the user has done X' hand-waving",
+        "q3_observable_outcome": "Then clauses reference verifiable signals (visible text, accessibilityLabel, DB row count, analytics event, alert title)",
+        "q4_atomic_scenario": "One user-meaningful flow per scenario; no two-different-features bundled together",
+        "q5_priority_assigned": "P0 / P1 / P2 label present"
+      },
+      "UAT-01": {"q1":"yes","q2":"yes","q3":"yes","q4":"yes","q5":"yes","verdict":"pass","rewritten":true,"rewrite_reason":"Slide-copy assertion loosened to topic match after code grounding (literal strings differ from ProductSpec 4.1 labels)."},
+      "UAT-02": {"q1":"yes","q2":"yes","q3":"yes","q4":"yes","q5":"yes","verdict":"pass"},
+      "UAT-03": {"q1":"yes","q2":"yes","q3":"yes","q4":"yes","q5":"yes","verdict":"pass"},
+      "UAT-04": {"q1":"yes","q2":"yes","q3":"yes","q4":"yes","q5":"yes","verdict":"pass","status":"blocked_by_drift_D6"},
+      "UAT-05": {"q1":"yes","q2":"yes","q3":"yes","q4":"yes","q5":"yes","verdict":"pass"},
+      "UAT-06": {"q1":"yes","q2":"yes","q3":"yes","q4":"yes","q5":"yes","verdict":"pass"},
+      "UAT-07": {"q1":"yes","q2":"yes","q3":"yes","q4":"yes","q5":"yes","verdict":"pass","status":"blocked_by_drift_D7"},
+      "UAT-08": {"q1":"yes","q2":"yes","q3":"yes","q4":"yes","q5":"yes","verdict":"pass","rewritten":true,"rewrite_reason":"Pool size assertion softened from 321 to ~320 due to D8 (actual 319)."},
+      "UAT-09": {"q1":"yes","q2":"yes","q3":"yes","q4":"yes","q5":"yes","verdict":"pass"},
+      "UAT-10": {"q1":"yes","q2":"yes","q3":"yes","q4":"yes","q5":"yes","verdict":"pass"},
+      "UAT-11": {"q1":"yes","q2":"yes","q3":"yes","q4":"yes","q5":"yes","verdict":"pass"},
+      "UAT-12": {"q1":"yes","q2":"yes","q3":"yes","q4":"yes","q5":"yes","verdict":"pass"},
+      "UAT-13": {"q1":"yes","q2":"yes","q3":"yes","q4":"yes","q5":"yes","verdict":"pass"},
+      "UAT-14": {"q1":"yes","q2":"yes","q3":"yes","q4":"yes","q5":"yes","verdict":"pass"},
+      "UAT-15": {"q1":"yes","q2":"yes","q3":"yes","q4":"yes","q5":"yes","verdict":"pass"},
+      "UAT-16": {"q1":"yes","q2":"yes","q3":"yes","q4":"yes","q5":"yes","verdict":"pass"},
+      "UAT-17": {"q1":"yes","q2":"yes","q3":"yes","q4":"yes","q5":"yes","verdict":"pass"},
+      "UAT-18": {"q1":"yes","q2":"yes","q3":"yes","q4":"yes","q5":"yes","verdict":"pass","note":"Bundles app-restart and device-reboot but both verify the same invariant (persistence); treating as one atomic 'no data loss' scenario."},
+      "UAT-19": {"q1":"yes","q2":"yes","q3":"yes","q4":"yes","q5":"yes","verdict":"pass"},
+      "UAT-20": {"q1":"yes","q2":"yes","q3":"yes","q4":"yes","q5":"yes","verdict":"pass","rewritten":true,"rewrite_reason":"Button label corrected from 'Set' to 'Set Reminder'; offset pill labels corrected to actual code values."},
+      "UAT-21": {"q1":"yes","q2":"yes","q3":"yes","q4":"yes","q5":"yes","verdict":"pass","rewritten":true,"rewrite_reason":"Visible label corrected from 'Reset Onboarding' to 'Reset onboarding' (lowercase o); flow tightened to acknowledge immediate route replace + post-relaunch evidence."},
+      "UAT-22": {"q1":"yes","q2":"yes","q3":"yes","q4":"yes","q5":"yes","verdict":"pass"},
+      "UAT-23": {"q1":"yes","q2":"yes","q3":"yes","q4":"yes","q5":"yes","verdict":"pass","status":"partially_blocked_by_drift_D7"},
+      "UAT-24": {"q1":"yes","q2":"yes","q3":"yes","q4":"yes","q5":"yes","verdict":"pass"},
+      "UAT-25": {"q1":"yes","q2":"yes","q3":"yes","q4":"yes","q5":"yes","verdict":"pass","added_in_validation":true},
+      "UAT-26": {"q1":"yes","q2":"yes","q3":"yes","q4":"yes","q5":"yes","verdict":"pass","added_in_validation":true},
+      "UAT-27": {"q1":"yes","q2":"yes","q3":"yes","q4":"yes","q5":"yes","verdict":"pass","added_in_validation":true},
+      "UAT-28": {"q1":"yes","q2":"yes","q3":"yes","q4":"yes","q5":"yes","verdict":"pass","added_in_validation":true},
+      "UAT-29": {"q1":"yes","q2":"yes","q3":"yes","q4":"yes","q5":"yes","verdict":"pass","added_in_validation":true},
+      "UAT-30": {"q1":"yes","q2":"yes","q3":"yes","q4":"yes","q5":"yes","verdict":"pass","added_in_validation":true}
+    },
+    "code_check": {
+      "verified": ["UAT-02","UAT-03","UAT-05","UAT-06","UAT-09","UAT-10","UAT-11","UAT-12","UAT-13","UAT-14","UAT-15","UAT-16","UAT-17","UAT-18","UAT-19","UAT-22","UAT-24"],
+      "rewritten": ["UAT-01","UAT-08","UAT-20","UAT-21"],
+      "blocked_by_drift": ["UAT-04","UAT-07","UAT-23"],
+      "report": "/Users/nav1885/workspace/MicroMoment/docs/test-reports/uat-code-check.md"
+    },
+    "cross_check": {
+      "added": ["UAT-25","UAT-26","UAT-27","UAT-28","UAT-29","UAT-30"],
+      "report": "/Users/nav1885/workspace/MicroMoment/docs/test-reports/uat-cross-check.md"
+    },
+    "drift": {
+      "new": [
+        {"id":"D6","severity":"medium","note":"HabitCard meta missing time-of-day (DesignSpec 2.3)","affects":["UAT-04"]},
+        {"id":"D7","severity":"medium","note":"Reduce Motion does not gate confetti or CheckButton spring (DesignSpec 6, 8)","affects":["UAT-07","UAT-23"]},
+        {"id":"D8","severity":"cosmetic","note":"DAILY_MESSAGES pool size is 319, spec claims 321 (ProductSpec 4.9, DesignSpec 2.6)","affects":["UAT-08"]}
+      ],
+      "report": "/Users/nav1885/workspace/MicroMoment/docs/test-reports/spec-drift.md"
+    }
+  },
+  "uat_validated": true,
+  "uat_validated_at": "2026-05-02T00:00:00Z",
+  "drift_summary": {
+    "resolved_since_run4": [
+      {"id": "F1/D1", "issue": 56, "note": "CheckButton default size raised to 44 (ec4b977)"},
+      {"id": "F2/D2", "issue": 57, "note": "DesignSpec 3.2 ratified footer Add Habit button (9e5d03b)"},
+      {"id": "F3", "issue": 58, "note": "Maestro CLI host environment — assumed unblocked for run #7"},
+      {"id": "F4", "issue": 59, "note": "UNIQUE INDEX uniq_completions_habit_date + INSERT OR IGNORE — atomic markComplete"},
+      {"id": "Save-target", "issue": 53, "note": "Flows updated to tap Save habit / Save changes via accessibilityLabel"},
+      {"id": "Run-script", "issue": 54, "note": "e2e/run_all.sh device hardcode removed (1bd0246)"},
+      {"id": "D4", "issue": null, "note": "amber and heatmap0..4 tokens documented in DesignSpec 1.1"}
+    ],
+    "open": [
+      {"id": "D3", "severity": "low", "note": "EmojiPicker described in DesignSpec 2.7 as reusable component but inlined in app/habit/new.tsx and app/habit/[id].tsx; no components/EmojiPicker.tsx file"},
+      {"id": "D5", "severity": "cosmetic", "note": "Stack.Screen header overrides live inside screen bodies (new.tsx, [id].tsx) instead of parent stack"},
+      {"id": "W6/N1", "severity": "low", "note": "grace_used column on completions is vestigial — no UI surfaces or sets it; DataModel 2.2 documents it"},
+      {"id": "D6", "severity": "medium", "note": "HabitCard meta missing time-of-day (DesignSpec 2.3); blocks UAT-04"},
+      {"id": "D7", "severity": "medium", "note": "Reduce Motion does not gate confetti or CheckButton spring; blocks UAT-07, partially UAT-23"},
+      {"id": "D8", "severity": "cosmetic", "note": "DAILY_MESSAGES has 319 entries, spec says 321"}
+    ],
+    "carry_forward_risks": [
+      {"id": "W1", "note": "Onboarding gate may flash (tabs) before redirect on cold launch — useEffect resolves after first frame"},
+      {"id": "W2", "note": "rescheduleAllNotifications cancels all then re-adds on every app start — small chance of cancelling a firing notification"},
+      {"id": "W4", "note": "channelId passed to scheduleNotificationAsync regardless of platform — Android-only, harmless on iOS but suggests un-split path"},
+      {"id": "W5", "note": "DraggableFlatList drag handle long-press (150ms) vs card long-press (400ms) — gestures may interfere on small targets; validate via UAT 16/17"}
+    ]
+  },
+  "deduped_against_closed_issues": [53, 54, 56, 57, 58, 59],
+  "artifacts": {
+    "regression_suite": "/Users/nav1885/workspace/MicroMoment/docs/test-reports/regression-suite.md",
+    "uat_plan": "/Users/nav1885/workspace/MicroMoment/docs/test-reports/uat-plan.md",
+    "uat_code_check": "/Users/nav1885/workspace/MicroMoment/docs/test-reports/uat-code-check.md",
+    "uat_cross_check": "/Users/nav1885/workspace/MicroMoment/docs/test-reports/uat-cross-check.md",
+    "spec_drift": "/Users/nav1885/workspace/MicroMoment/docs/test-reports/spec-drift.md",
+    "state": "/Users/nav1885/workspace/MicroMoment/docs/test-reports/.flint-state.json"
+  },
+  "next_phase": "finalize",
+  "execute_results": {
+    "started_at": "2026-05-02",
+    "device": "4549ECE8-9346-42D1-A401-1855ADD79968",
+    "wrapper": "/Users/nav1885/workspace/MicroMoment/e2e/run_for_flint.sh",
+    "totals": {"pass": 0, "fail": 21, "timeout": 1, "blocked": 0, "total": 22},
+    "common_root_cause": "Maestro executed against the booted Release build. 2 flows (00_launch, 18_restore_cap_block) failed at app launch/clear-state with 'Unable to set permissions for app com.nav1885.micromoment: Failed to connect to /127.0.0.1:7001' — idb_companion handshake on the simulator. Remaining 19 flows progressed past launch into _skip_onboarding.yaml and failed/timed out at Tap regex 'Next' — the onboarding 'Next' control is either not present, not yet rendered, or selector mismatched. 1 flow (20_reset_onboarding) was killed by the perl alarm (per-flow 120s wall clock).",
+    "execute_totals": {"pass": 0, "fail": 21, "timeout": 1},
+    "flows": {
+      "00_launch":             {"status": "fail",    "log": "/tmp/flint-00_launch.log",             "screenshot": "/tmp/flint-00_launch-fail.png",             "failed_step": "Launch app -> Unable to set permissions: Failed to connect to /127.0.0.1:7001 (idb)"},
+      "01_add_habit":          {"status": "fail",    "log": "/tmp/flint-01_add_habit.log",          "screenshot": "/tmp/flint-01_add_habit-fail.png",          "failed_step": "_skip_onboarding.yaml -> Tap regex 'Next' (timed out mid-tap)"},
+      "02_complete_habit":     {"status": "fail",    "log": "/tmp/flint-02_complete_habit.log",     "screenshot": "/tmp/flint-02_complete_habit-fail.png",     "failed_step": "_skip_onboarding.yaml -> Tap regex 'Next' (Element not found)"},
+      "03_edit_habit":         {"status": "fail",    "log": "/tmp/flint-03_edit_habit.log",         "screenshot": "/tmp/flint-03_edit_habit-fail.png",         "failed_step": "_skip_onboarding.yaml -> Tap regex 'Next' (timed out mid-tap)"},
+      "04_delete_habit":       {"status": "fail",    "log": "/tmp/flint-04_delete_habit.log",       "screenshot": "/tmp/flint-04_delete_habit-fail.png",       "failed_step": "_skip_onboarding.yaml -> Tap regex 'Next' (Element not found)"},
+      "05_five_habit_cap":     {"status": "fail",    "log": "/tmp/flint-05_five_habit_cap.log",     "screenshot": "/tmp/flint-05_five_habit_cap-fail.png",     "failed_step": "_skip_onboarding.yaml -> Tap regex 'Next' (Element not found)"},
+      "06_habit_detail_view":  {"status": "fail",    "log": "/tmp/flint-06_habit_detail_view.log",  "screenshot": "/tmp/flint-06_habit_detail_view-fail.png",  "failed_step": "_skip_onboarding.yaml -> Tap regex 'Next' (Element not found)"},
+      "07_reminder":           {"status": "fail",    "log": "/tmp/flint-07_reminder.log",           "screenshot": "/tmp/flint-07_reminder-fail.png",           "failed_step": "_skip_onboarding.yaml -> Tap regex 'Next' (Element not found)"},
+      "08_progress_screen":    {"status": "fail",    "log": "/tmp/flint-08_progress_screen.log",    "screenshot": "/tmp/flint-08_progress_screen-fail.png",    "failed_step": "_skip_onboarding.yaml -> Tap regex 'Next' (Element not found)"},
+      "09_settings_screen":    {"status": "fail",    "log": "/tmp/flint-09_settings_screen.log",    "screenshot": "/tmp/flint-09_settings_screen-fail.png",    "failed_step": "_skip_onboarding.yaml -> Tap regex 'Next' (Element not found)"},
+      "10_archive_and_restore":{"status": "fail",    "log": "/tmp/flint-10_archive_and_restore.log","screenshot": "/tmp/flint-10_archive_and_restore-fail.png","failed_step": "_skip_onboarding.yaml -> Tap regex 'Next' (timed out mid-tap)"},
+      "11_add_habit_full":     {"status": "fail",    "log": "/tmp/flint-11_add_habit_full.log",     "screenshot": "/tmp/flint-11_add_habit_full-fail.png",     "failed_step": "_skip_onboarding.yaml -> Tap regex 'Next' (Element not found)"},
+      "12_double_complete":    {"status": "fail",    "log": "/tmp/flint-12_double_complete.log",    "screenshot": "/tmp/flint-12_double_complete-fail.png",    "failed_step": "_skip_onboarding.yaml -> Tap regex 'Next' (Element not found)"},
+      "13_persistence":        {"status": "fail",    "log": "/tmp/flint-13_persistence.log",        "screenshot": "/tmp/flint-13_persistence-fail.png",        "failed_step": "_skip_onboarding.yaml -> Tap regex 'Next' (Element not found)"},
+      "14_streak_badge":       {"status": "fail",    "log": "/tmp/flint-14_streak_badge.log",       "screenshot": "/tmp/flint-14_streak_badge-fail.png",       "failed_step": "_skip_onboarding.yaml -> Tap regex 'Next' (Element not found)"},
+      "15_milestone_confetti": {"status": "fail",    "log": "/tmp/flint-15_milestone_confetti.log", "screenshot": "/tmp/flint-15_milestone_confetti-fail.png", "failed_step": "_skip_onboarding.yaml -> Tap regex 'Next' (Element not found)"},
+      "16_reorder":            {"status": "fail",    "log": "/tmp/flint-16_reorder.log",            "screenshot": "/tmp/flint-16_reorder-fail.png",            "failed_step": "_skip_onboarding.yaml -> Tap regex 'Next' (Element not found)"},
+      "17_longpress_menu":     {"status": "fail",    "log": "/tmp/flint-17_longpress_menu.log",     "screenshot": "/tmp/flint-17_longpress_menu-fail.png",     "failed_step": "_skip_onboarding.yaml -> Tap regex 'Next' (Element not found)"},
+      "18_restore_cap_block":  {"status": "fail",    "log": "/tmp/flint-18_restore_cap_block.log",  "screenshot": "/tmp/flint-18_restore_cap_block-fail.png",  "failed_step": "Launch app -> Unable to set permissions: Failed to connect to /127.0.0.1:7001 (idb)"},
+      "19_tabs":               {"status": "fail",    "log": "/tmp/flint-19_tabs.log",               "screenshot": "/tmp/flint-19_tabs-fail.png",               "failed_step": "_skip_onboarding.yaml -> Tap regex 'Next' (timed out mid-tap)"},
+      "20_reset_onboarding":   {"status": "timeout", "log": "/tmp/flint-20_reset_onboarding.log",   "screenshot": "/tmp/flint-20_reset_onboarding-fail.png",   "failed_step": "perl alarm (120s wall clock)"},
+      "21_drag_hint":          {"status": "fail",    "log": "/tmp/flint-21_drag_hint.log",          "screenshot": "/tmp/flint-21_drag_hint-fail.png",          "failed_step": "_skip_onboarding.yaml -> Tap regex 'Next' (Element not found)"}
+    }
+  }
+}

--- a/docs/test-reports/filed-issues-2026-05-02.md
+++ b/docs/test-reports/filed-issues-2026-05-02.md
@@ -1,0 +1,23 @@
+# Filed Issues — 2026-05-02 (post-spec-baseline run #4)
+
+Branch: fix/e2e-runner-and-tap-targets
+Tester: Flint (iOS QA)
+
+## Newly filed by this run
+
+| # | Title | Labels | Severity |
+|---|---|---|---|
+| 56 | CheckButton size 36pt violates 44x44 a11y minimum and DesignSpec 2.4 (40x40) | qa-flint, testing, ios, p1 | P1 |
+| 57 | Today screen has inline 'Add Habit' footer button instead of header FAB '+' (DesignSpec 3.2 drift) | qa-flint, testing, ui, p1 | P1 |
+| 58 | Maestro CLI not installed on test host — entire E2E suite cannot run | qa-flint, testing, devops, p0 | P0 |
+| 59 | Race in markComplete: hasCompletionToday + insertCompletion is not atomic; no DB UNIQUE on (habit_id, completed_date) | qa-flint, testing, data, p2 | P2 |
+
+## Pre-existing open qa-flint issues (not refiled)
+
+| # | Title | Status |
+|---|---|---|
+| 53 | Maestro flows reference non-existent 'Save Habit' / 'Save Changes' tap targets | Believed addressed in this branch's flow updates; cannot verify until #58 unblocks |
+| 54 | e2e/run_all.sh hardcodes Android device — iOS test runs cannot use it | Believed addressed in this branch's run_all.sh rewrite (auto-detects booted iOS sim or first adb device); cannot verify until #58 unblocks |
+
+## Dedupe verification
+\`gh issue list --label qa-flint --state open --json number,title\` was run before filing. Numbers 53 and 54 were the only pre-existing open issues. None of #56–#59 duplicate them.

--- a/docs/test-reports/ios-post-spec-baseline-report.md
+++ b/docs/test-reports/ios-post-spec-baseline-report.md
@@ -1,0 +1,103 @@
+# iOS Test Report — post-spec-baseline (run #4)
+
+Date: 2026-05-02
+Project: MicroMoment
+Branch: fix/e2e-runner-and-tap-targets
+Tester: Flint (iOS QA)
+Specs: docs/ProductSpec.md, docs/DesignSpec.md, docs/DataModel.md
+
+## Summary
+
+- Total tests / checks: 33 regression items (R01–R33) + 22 UAT flows (uat-id 00–21) + 6 static suites
+- ✅ Pass (static): 38
+- ❌ Fail: 4
+- ⚠️ Risk: 6
+- 🔲 Blocked (E2E): 22 (entire Maestro suite — Maestro CLI not installed on host; see #58)
+
+## Phase Go/No-Go: NO-GO
+
+Reason: Maestro binary is absent on the test host so the full E2E regression cannot be validated for run #4; in addition, two design-spec drifts (CheckButton size, missing header FAB) and one data-correctness risk (TOCTOU on markComplete) must be addressed before this phase is signed off.
+
+## Spec ↔ Code drift summary
+
+| # | Drift | Spec ref | Code |
+|---|---|---|---|
+| D1 | CheckButton renders 36×36, spec says 40×40 and a11y guidance ≥40×40 | DesignSpec § 2.4, § 6 | components/CheckButton.tsx:19, components/HabitCard.tsx:128 |
+| D2 | "FAB-style '+' in header right" not present; instead inline footer "Add Habit" button | DesignSpec § 3.2 | app/(tabs)/index.tsx:174-206 |
+| D3 | DesignSpec lists "EmojiPicker" as a reusable component § 2.7 but emoji grid is duplicated inline in new.tsx and [id].tsx | DesignSpec § 2.7 | app/habit/new.tsx:38-43, app/habit/[id].tsx:23-28 |
+| D4 | Color tokens \`amber\`, \`heatmap0..4\` exist in code but absent from DesignSpec § 1.1 token table (heatmap range is described prose-only "blue gradient") | DesignSpec § 1.1 | constants/colors.ts |
+| D5 | DesignSpec § 4 navigation says habit/new is "modal" with no swipe-down for onboarding only — habit/new currently uses presentation: 'modal' (correct), but Stack.Screen header config is overridden inline within new.tsx body, fighting the parent stack (cosmetic) | DesignSpec § 4 | app/_layout.tsx:47, app/habit/new.tsx:121-141 |
+| D6 | ProductSpec § 4.1 says onboarding is "Skippable. Completion writes onboarding_complete to AsyncStorage and emits an onboarding_completed analytics event" — analytics event is fired, but only after Skip button which calls handleGetStarted. ✓ Verified. No drift. | — | — |
+
+## Failed tests (❌)
+
+| ID | Test | Expected | Found | File:line | Issue |
+|---|---|---|---|---|---|
+| F1 | CheckButton tap target ≥ 40×40 (DesignSpec § 6) | 40×40 minimum, 44×44 per Apple HIG | 36×36 (size default 36, used unchanged) | components/CheckButton.tsx:19, components/HabitCard.tsx:128 | #56 |
+| F2 | Today screen header FAB "+" (DesignSpec § 3.2) | "+" icon top-right of header, disabled at cap | No header rendered; inline footer "Add Habit" button instead | app/(tabs)/index.tsx:174-206 | #57 |
+| F3 | E2E suite executable (R01–R28, UAT 00–21) | maestro CLI present on host PATH | "maestro: command not found" for all 22 flows | /tmp/maestro-run.log; e2e/run_all.sh:38 | #58 |
+| F4 | One-completion-per-day invariant DB-enforced (DataModel § 2.4) | UNIQUE constraint or atomic INSERT … ON CONFLICT | TOCTOU between hasCompletionToday and insertCompletion; no DB UNIQUE | store/habitStore.ts:187, db/schema.ts:28 | #59 |
+
+## Risks (⚠️)
+
+| ID | Description | Likelihood | Mitigation |
+|---|---|---|---|
+| W1 | Onboarding gate flashes (tabs) before redirect on cold launch — useEffect runs after rootState.key resolves, so initial frame shows Today before navigating to /onboarding | Medium | Render null while AsyncStorage check pending; or block Stack mount until flag known |
+| W2 | rescheduleAllNotifications cancels ALL scheduled notifications globally on every app start, then re-schedules. If a notification fires while the app is launching it could be cancelled mid-flight | Low | Migrate to per-id cancel-and-replace, or only reschedule when habits[] changed |
+| W3 | hasCompletionToday + insertCompletion race (W4-related: see F4 / #59) | Low | DB UNIQUE index (#59) |
+| W4 | Reminder time scheduled in 24h DAILY trigger uses ChannelId on iOS path too — \`channelId\` is Android-only, harmless on iOS but suggests cross-platform handling not split. | Low | Pass channelId only when EXPO_OS === 'android' |
+| W5 | DraggableFlatList shares Pressable + onLongPress (drag) + onLongPress (open swipe menu) on the same card. delayLongPress=400 on parent vs delayLongPress=150 on drag handle — drag handle wins by being a separate hitbox, but on small phones / large fingers the gestures can interfere | Medium | Add hitSlop to drag handle, make delays distinct, validate with E2E once #58 unblocks |
+| W6 | DataModel mentions \`grace_used\` column on completions but no UI surfaces or sets it; vestigial column adds confusion | Low | Either implement grace-day feature or remove column / spec entry |
+
+## Blocked (🔲)
+
+All 22 Maestro flows (00–21) cannot execute — see #58. Authored 11 new flows (11_add_habit_full, 12_double_complete, 13_persistence, 14_streak_badge, 15_milestone_confetti, 16_reorder, 17_longpress_menu, 18_restore_cap_block, 19_tabs, 20_reset_onboarding, 21_drag_hint) — they are static (parsed-only) until #58 is fixed.
+
+## Static suites
+
+### Suite 1 — iOS Platform Behavior
+- Location: N/A (no location features) — PASS
+- Audio: N/A (no audio features) — PASS
+- Security: All persistence is local SQLite + AsyncStorage flag; no secrets in repo (Sentry/PostHog keys read from process.env); HTTPS not used because local-first — PASS
+- Layout / SafeArea: every screen wraps in \`SafeAreaView\`. ✅
+- StatusBar: \`StatusBar style\` toggled by colorScheme in app/_layout.tsx:42 — PASS
+- Keyboard avoidance: KeyboardAvoidingView used in new.tsx and [id].tsx with headerHeight offset — PASS
+- Swipe-back: Onboarding gestureEnabled: false intentionally; rest enabled — PASS
+- StoreKit / IAP: not applicable — PASS
+
+### Suite 2 — Navigation Flows
+PS § 5.1–5.6 mapped to flows 00, 01, 02, 03, 07, 10. All currently BLOCKED on E2E (#58). Static read of code paths confirms each flow is reachable. PASS (static).
+
+### Suite 3 — UX Compliance
+- Colors: light tokens match DesignSpec § 1.1 ✓ except undocumented \`amber\` and \`heatmap*\` (D4) — RISK
+- Typography: title (28/700/-0.5), section labels (11/700/letterSpacing 1) match. Body sizes match. ✓
+- Spacing: screen padding 20 ✓; card padding 14 ✓; section gaps 24/28 ✓
+- Components: HabitCard, CheckButton, Button, AnimatedPressable, CompletionRing, DailyMessage all present — except EmojiPicker is inlined (D3, minor)
+- Header FAB drift (D2 / F2)
+
+### Suite 4 — Feature Completeness
+All ProductSpec § 4 features wired: 4.1 Onboarding ✓, 4.2 CRUD ✓, 4.3 Check-in ✓, 4.4 Streaks/milestones ✓, 4.5 Drag ✓, 4.6 Swipe/long-press ✓, 4.7 Progress ✓, 4.8 Reminders ✓, 4.9 Daily message ✓, 4.10 Dark mode ✓, 4.11 Settings ✓.
+
+### Suite 5 — Edge cases
+- Offline: PASS — no network code outside analytics best-effort
+- Empty list state on Today / Progress / Settings — all present ✓
+- Long names: TextInput maxLength 50 ✓
+- 5-habit cap enforced in store and UI ✓
+- Force-quit recovery: SQLite + AsyncStorage flag, no in-memory state to lose — PASS
+
+### Suite 6 — Accessibility
+- Labels: every Pressable has accessibilityRole + accessibilityLabel ✓
+- Tap target ≥ 44×44: FAIL (CheckButton 36×36, F1 / #56)
+- Reduce-motion respected in CheckButton + AnimatedPressable ✓
+- Colors: text/textSecondary contrast on light/dark backgrounds appears WCAG AA but not formally audited — RISK low
+- VoiceOver order: not manually verified — BLOCKED until E2E + manual run
+
+## Recommendations (ordered)
+
+1. **Provision Maestro on the test host** (resolves #58). Without this, run #5 will be a duplicate report.
+2. **Fix CheckButton tap target** to 44×44 (resolves #56) — single-line default change in components/CheckButton.tsx + optional hitSlop.
+3. **Resolve header-FAB drift** (#57): either update the DesignSpec § 3.2 to ratify the inline footer button (cheapest), or implement the header "+".
+4. **Add UNIQUE index on completions(habit_id, completed_date)** (#59) and switch insertCompletion to ON CONFLICT DO NOTHING.
+5. **Fix onboarding flash (W1)** — gate Stack rendering on AsyncStorage hydration before first paint.
+6. **Decide on \`grace_used\` column (W6)** — implement grace day or drop the column from schema.
+7. After #58 lands, re-run run_all.sh, expect at minimum the 11 pre-existing flows to pass; then triage 11–21 for any environment-specific failures.

--- a/docs/test-reports/regression-suite.md
+++ b/docs/test-reports/regression-suite.md
@@ -1,0 +1,75 @@
+# MicroMoment — Regression Suite
+
+Date: 2026-05-02
+Phase: post-spec-baseline (run #7 — phased, plan)
+Branch: main
+Specs: docs/ProductSpec.md, docs/DesignSpec.md, docs/DataModel.md
+
+Priorities:
+- **P0** — must pass for any release. Core data correctness, cap, persistence, on-device data integrity.
+- **P1** — must pass for a phase to be GO. Primary UX, navigation, theming.
+- **P2** — should pass; cosmetic / minor edge cases.
+
+Status legend: `planned` (queued for execute phase), `static` (verified by code read only — no flow), `manual` (no automated coverage available).
+
+| ID  | Pri | Area              | Test                                                                                       | Spec ref          | Flow file / Source                                | Status   |
+|-----|-----|-------------------|--------------------------------------------------------------------------------------------|-------------------|---------------------------------------------------|----------|
+| R01 | P0  | Onboarding        | First launch with no flag pushes /onboarding modal                                         | PS 4.1 / 5.1      | 00_launch.yaml                                    | planned  |
+| R02 | P0  | Onboarding        | Skip / Get Started writes onboarding_complete and lands on Today                           | PS 4.1            | _skip_onboarding.yaml                             | planned  |
+| R03 | P0  | Habit CRUD        | Create habit (defaults) appears on Today                                                   | PS 4.2 / 5.2      | 01_add_habit.yaml                                 | planned  |
+| R04 | P0  | Habit CRUD        | Create habit with all fields (emoji, name, time-of-day, duration, reminder)                | PS 4.2            | 11_add_habit_full.yaml                            | planned  |
+| R05 | P0  | Habit CRUD        | Edit habit — name change persists on Today                                                 | PS 4.2 / 5.4      | 03_edit_habit.yaml                                | planned  |
+| R06 | P0  | Habit CRUD        | Delete habit removes from Today and confirms via alert                                     | PS 4.2            | 04_delete_habit.yaml                              | planned  |
+| R07 | P0  | Habit CRUD        | 5-habit cap blocks 6th creation; banner / disabled footer button                           | PS 4.2 / 6        | 05_five_habit_cap.yaml                            | planned  |
+| R08 | P0  | Daily check-in    | Tap CheckButton marks complete, shows checkmark, opacity drops                             | PS 4.3 / 5.3      | 02_complete_habit.yaml                            | planned  |
+| R09 | P0  | Daily check-in    | Double-tap silently prevented (idempotent)                                                 | PS 4.3 / DM 2.4   | 12_double_complete.yaml                           | planned  |
+| R10 | P0  | Persistence       | Created habit survives force-quit + relaunch                                               | PS 6              | 13_persistence.yaml                               | planned  |
+| R11 | P0  | FK cascade        | Deleting habit also removes its completions                                                | PS 6 / DM 2.4     | db/schema.ts:31 (ON DELETE CASCADE)               | static   |
+| R12 | P0  | Atomicity         | One completion per (habit, day) DB-enforced via UNIQUE index + INSERT OR IGNORE            | DM 2.4            | db/schema.ts:52, db/completions.ts:35             | static   |
+| R13 | P1  | Streaks           | Streak count appears as 🔥 N when ≥ 2 consecutive days                                      | PS 4.4            | 14_streak_badge.yaml                              | planned  |
+| R14 | P1  | Milestone         | Milestone (7/14/21/30/60/90/180/365) triggers confetti                                     | PS 4.4            | 15_milestone_confetti.yaml                        | planned  |
+| R15 | P1  | Drag-to-reorder   | Drag handle reorders habits; persists                                                      | PS 4.5            | 16_reorder.yaml                                   | planned  |
+| R16 | P1  | Long-press        | 400ms long-press on card opens swipe actions                                               | PS 4.6            | 17_longpress_menu.yaml                            | planned  |
+| R17 | P1  | Swipe-left        | Swipe-left on card reveals Edit (green) + Delete (red)                                     | PS 4.6 / DS 2.3   | 03_edit_habit.yaml (partial)                      | planned  |
+| R18 | P1  | Detail            | Tap card → Detail screen → Mark Complete → Completed Today                                 | DS 3.6            | 06_habit_detail_view.yaml                         | planned  |
+| R19 | P1  | Reminder          | Set reminder via modal; saves with offset                                                  | PS 4.8 / 5.6      | 07_reminder.yaml                                  | planned  |
+| R20 | P1  | Reminder          | Reminder rescheduled on every app start                                                    | DM 5              | utils/notifications.ts (rescheduleAllNotifications)| static   |
+| R21 | P1  | Progress          | Progress tab renders Last 7 days, Habits list, 8-week heatmap                              | PS 4.7 / DS 3.3   | 08_progress_screen.yaml                           | planned  |
+| R22 | P1  | Progress          | Heatmap cells colored by completion ratio (0–4) using heatmap0..4 tokens                   | PS 4.7 / DS 1.1   | constants/colors.ts (heatmap0..4)                 | static   |
+| R23 | P1  | Settings          | Settings shows Archived, Version, Reset Onboarding                                         | PS 4.11 / DS 3.4  | 09_settings_screen.yaml                           | planned  |
+| R24 | P1  | Archive/restore   | Archive habit removes from Today, appears in Settings, restore returns it                  | PS 4.2 / 5.5      | 10_archive_and_restore.yaml                       | planned  |
+| R25 | P1  | Restore cap       | Restore blocked when at 5 active                                                           | PS 4.2 / DM 3.2   | 18_restore_cap_block.yaml                         | planned  |
+| R26 | P1  | Daily message     | Today shows daily message from 321-pool                                                    | PS 4.9            | components/DailyMessage.tsx + constants/messages.ts| static   |
+| R27 | P1  | Dark mode         | Light/dark themes render every screen with no unreadable contrast                          | PS 4.10 / PS 6    | manual                                            | manual   |
+| R28 | P1  | Tabs              | Three tabs (Today/Progress/Settings) navigable; active tint = primary                      | DS 4              | 19_tabs.yaml                                      | planned  |
+| R29 | P1  | Onboarding reset  | Settings → Reset Onboarding clears flag and shows onboarding next launch                   | PS 4.11           | 20_reset_onboarding.yaml                          | planned  |
+| R30 | P1  | Add Habit footer  | Footer Add Habit button visible; primary-tinted; disabled state at cap (opacity 0.4)       | DS 3.2            | 05_five_habit_cap.yaml + 21_drag_hint.yaml        | planned  |
+| R31 | P1  | Save target a11y  | Save / Save changes have stable accessibilityLabel ("Save habit" / "Save changes")          | DS 6              | app/habit/new.tsx:101, app/habit/[id].tsx:228     | static   |
+| R32 | P1  | CheckButton size  | CheckButton rendered ≥ 44×44                                                               | DS 2.4 / 6 / HIG  | components/CheckButton.tsx:19 (size=44)           | static   |
+| R33 | P2  | Empty state       | No habits → "🌱 No habits yet" empty state with footer Add Habit                            | DS 3.2            | 00_launch.yaml                                    | planned  |
+| R34 | P2  | Drag hint         | Drag hint visible only when ≥ 2 habits                                                     | PS 4.5 / DS 3.2   | 21_drag_hint.yaml                                 | planned  |
+| R35 | P2  | Reduce motion     | Animations & haptics skipped under Reduce Motion                                            | DS 6              | manual                                            | manual   |
+| R36 | P2  | Offline           | App fully functional with airplane mode                                                    | PS 6              | manual                                            | manual   |
+| R37 | P2  | Heatmap snap      | Heatmap grid snaps to Monday                                                               | PS 4.7            | app/(tabs)/progress.tsx                           | static   |
+
+## Counts by priority
+- P0: 12  (R01–R12)
+- P1: 19  (R13–R31; R32 is P1)  → 19 P1 + 1 (R32) = 20
+- P2: 5   (R33–R37)
+- Total: 37
+
+> Correction: P0=12, P1=20 (R13–R32), P2=5. Grand total 37.
+
+## Carry-forward drift (open)
+- D3: EmojiPicker still inlined in `app/habit/new.tsx` and `app/habit/[id].tsx`; no `components/EmojiPicker.tsx` exists. DesignSpec § 2.7 still describes it as a reusable component.
+- D5: `Stack.Screen` header overrides live in screen bodies (`new.tsx`, `[id].tsx`) instead of the parent stack. Cosmetic.
+- W6 / N1: `grace_used` column on `completions` is vestigial — no UI surfaces it. Either implement grace-day or drop column / DataModel entry.
+
+## Resolved since run #4 (deduped)
+- F1 / D1 / #56 — CheckButton size default raised to 44 (commit ec4b977).
+- F2 / D2 / #57 — DesignSpec § 3.2 ratified the footer Add Habit button (commit 9e5d03b); no longer drift.
+- F3 / #58 — Maestro CLI environment unblock; assume host has Maestro for run #7.
+- F4 / #59 — `UNIQUE INDEX uniq_completions_habit_date` + `INSERT OR IGNORE` make markComplete atomic.
+- #53 — Maestro flows updated to tap "Save habit" / "Save changes" by accessibilityLabel.
+- #54 — `e2e/run_all.sh` device hardcode removed.
+- D4 — `amber`, `heatmap0..4` light + dark scales now documented in DesignSpec § 1.1.

--- a/docs/test-reports/spec-drift.md
+++ b/docs/test-reports/spec-drift.md
@@ -1,0 +1,30 @@
+# Spec-vs-Code Drift — Found During UAT Plan Validation
+
+**Date:** 2026-05-02
+**Resolved:** 2026-05-10
+**Tester:** Flint (iOS QA)
+
+All three drifts uncovered during UAT validation are now resolved in code.
+
+---
+
+## D6 — HabitCard meta missing time-of-day — RESOLVED
+
+- **Spec:** DesignSpec §2.3 — meta is "duration · time-of-day"
+- **Was:** `components/HabitCard.tsx` rendered only `{N} min`
+- **Fix:** Added inline `TIME_OF_DAY_META` map; card now renders `"{N} min · 🌅 Morning"` etc.
+- **Unblocks:** UAT-04
+
+## D7 — Reduce Motion not gated for confetti or CheckButton spring — RESOLVED
+
+- **Spec:** DesignSpec §6 and §8 — "All motion bypassed under reduce-motion"
+- **Was:** Confetti and CheckButton spring fired unconditionally
+- **Fix:** Added `hooks/useReduceMotion.ts` (subscribes to `AccessibilityInfo.reduceMotionChanged`). Confetti `start()` in `app/(tabs)/index.tsx` and CheckButton spring + haptic in `components/CheckButton.tsx` both gated on `!reduceMotion`.
+- **Unblocks:** UAT-07, UAT-23
+
+## D8 — DAILY_MESSAGES off by 2 — RESOLVED
+
+- **Spec:** ProductSpec §4.9 / DesignSpec §2.6 — "321-message pool"
+- **Was:** `constants/messages.ts` had 319 entries
+- **Fix:** Added 2 more messages to reach 321.
+- **Unblocks:** cosmetic only (UAT-08 was already passing modulo rotation)

--- a/docs/test-reports/uat-code-check.md
+++ b/docs/test-reports/uat-code-check.md
@@ -1,0 +1,288 @@
+# UAT — Code-Grounded Check
+
+**Date:** 2026-05-02
+**Plan under review:** `docs/test-reports/uat-plan.md` (24 scenarios)
+
+Each scenario is verified mechanically against the codebase. For every `tapOn`/`assertVisible` token in the scenario we confirm it exists as visible text or `accessibilityLabel` in `app/` or `components/`. State preconditions are verified against `db/schema.ts` or AsyncStorage usage in `app/_layout.tsx`. Spec refs are verified to resolve to real headings.
+
+Legend: ✅ verified — ❌ broken (UAT rewritten in-place) — ⚠️ drift (escalated)
+
+---
+
+## UAT-01 — See onboarding on first launch
+- AsyncStorage key `onboarding_complete` — `app/_layout.tsx:13`, `app/onboarding.tsx:18` ✅
+- `gestureEnabled: false` on onboarding stack — `app/_layout.tsx:45` ✅
+- "Next" / "Get Started" visible text — `app/onboarding.tsx:115` ✅
+- "Skip" visible text — `app/onboarding.tsx:126` ✅
+- accessibilityLabel "Skip onboarding" — `app/onboarding.tsx:124` ✅
+- Slide headline copy. UAT echoed ProductSpec §4.1 verbatim ("Five minutes/day", "5 habits max", "Streaks & milestones"). Actual code copy at `app/onboarding.tsx:31–44` is a thematic expansion ("Five minutes. Every day. That's it.", "Pick up to 5 habits to focus on.", "Check in daily. Build streaks. Grow."). ProductSpec list reads as topic labels, not verbatim slide copy. **UAT-01 rewritten** to refer to "three sequential slides covering five-minute daily action, five-habit focus, and streaks/milestones" rather than asserting exact strings.
+- Spec refs ProductSpec §4.1, §5.1, DesignSpec §3.1, §4 — all resolve. ✅
+
+Verdict: ✅ verified (after rewrite)
+
+---
+
+## UAT-02 — Complete onboarding and land on empty Today tab
+- Next button → "Get Started" on last slide — `app/onboarding.tsx:115` ✅
+- AsyncStorage `setItem('onboarding_complete', '1')` — `app/onboarding.tsx:65` ✅
+- `trackOnboardingCompleted()` — `app/onboarding.tsx:66`, `utils/analytics.ts` ✅
+- Today tab empty state with "Add Habit" footer button — `app/(tabs)/index.tsx:143–151, 174–206` ✅
+- "Add Habit" visible text — `app/(tabs)/index.tsx:202` ✅
+- Subsequent launch skips onboarding via gate — `app/_layout.tsx:21–28` ✅
+- Spec refs resolve ✅
+
+Verdict: ✅ verified
+
+---
+
+## UAT-03 — Skip onboarding
+- Skip button at `app/onboarding.tsx:120–128` calls `handleGetStarted` → sets `onboarding_complete` → routes to `(tabs)` ✅
+- Spec ref ProductSpec §4.1 resolves ✅
+
+Verdict: ✅ verified
+
+---
+
+## UAT-04 — Add my first habit in under 30 seconds
+- Add Habit footer — `app/(tabs)/index.tsx:174–206` ✅
+- New Habit modal: EmojiPicker, name TextInput, time-of-day pills, duration stepper, Save — `app/habit/new.tsx:147–280` ✅
+- Save accessibilityLabel "Save habit" — `app/habit/new.tsx:101` ✅
+- Habit appears on Today with emoji + name + meta — `components/HabitCard.tsx:94–125` ✅
+- **❌ Broken**: UAT asserts meta reads `"5 min · morning"`. Code at `components/HabitCard.tsx:113–116` renders only `{time_estimate_min} min` — time-of-day is NOT part of the Today-tab card meta. DesignSpec §2.3 says "meta (duration · time-of-day)" which the code does not honor. Escalated to spec-drift (D6). UAT-04 marked `[BLOCKED: spec drift]`.
+- Spec refs resolve ✅
+
+Verdict: ❌ broken → blocked by drift D6
+
+---
+
+## UAT-05 — Check in a habit for today
+- CheckButton spring 1 → 1.3 → 1 — `components/CheckButton.tsx:30–32` ✅
+- Active fill primary green + white ✓ — `components/CheckButton.tsx:57, 64` ✅
+- Haptic Light, gated by ReduceMotion — `components/CheckButton.tsx:34–38` ✅
+- Card dims opacity 0.45 + completedText — `components/HabitCard.tsx:33, 105` ✅
+- 🔥 N badge when streak ≥ 2 — `components/HabitCard.tsx:117–123` ✅
+- Spec refs resolve ✅
+
+Verdict: ✅ verified
+
+---
+
+## UAT-06 — Streak count and heatmap update immediately after check-in
+- markComplete idempotent via UNIQUE index + `INSERT OR IGNORE` — `db/completions.ts:35`, `db/schema.ts:52` ✅
+- Streak recomputed via `loadStreaks()` — `app/(tabs)/index.tsx:74` ✅
+- Progress tab last-7-days dot strip — `app/(tabs)/progress.tsx:119–141` ✅
+- 8-week heatmap — `app/(tabs)/progress.tsx:198–219` ✅
+- Spec refs resolve ✅
+
+Verdict: ✅ verified
+
+---
+
+## UAT-07 — Milestone confetti at 7-day streak
+- ConfettiCannon count=120, fallSpeed=3000 — `app/(tabs)/index.tsx:210–217` ✅ (matches DesignSpec §5)
+- `trackStreakMilestone(habitId, newStreak)` — `app/(tabs)/index.tsx:72` ✅
+- Milestone set includes 7 — `app/(tabs)/index.tsx:27` ✅
+- **⚠️ Drift**: UAT asserts "if Reduce Motion is on, the confetti is suppressed but the badge still updates". Code at `app/(tabs)/index.tsx:71` fires confetti unconditionally — no `AccessibilityInfo.isReduceMotionEnabled()` gate around `confettiRef.current?.start()`. DesignSpec §8 says "All motion bypassed under reduce-motion". Escalated to spec-drift (D7). UAT-07 marked `[BLOCKED: spec drift]`.
+
+Verdict: ⚠️ blocked by drift D7
+
+---
+
+## UAT-08 — Daily motivational message rotates
+- `DailyMessage` rendered in Today header — `app/(tabs)/index.tsx:132`, `components/DailyMessage.tsx` ✅
+- `getDailyMessage()` selects by day-of-year — `constants/messages.ts` (`getDayOfYear` + modulo) ✅
+- **❌ Broken**: UAT asserts "321-entry pool". Code has 319 entries (`grep '^  "' constants/messages.ts | wc -l` = 319). ProductSpec §4.9 and DesignSpec §2.6 both assert 321 — minor copy drift. Escalated to spec-drift (D8). UAT-08 rewritten to reference the ~320-entry pool without asserting an exact count, since rotation behavior is the testable property; drift is logged but not blocking.
+
+Verdict: ❌ rewritten + drift D8 noted
+
+---
+
+## UAT-09 — Edit a habit via swipe-left
+- Swipeable with Edit (primary/green) + Delete (danger/red) — `components/HabitCard.tsx:48–67` ✅
+- Visible text "Edit" / "Delete" — `components/HabitCard.tsx:56, 64` ✅
+- Edit navigates to `/habit/[id]?mode=edit` — `app/(tabs)/index.tsx:89–91`, auto-enters edit at `app/habit/[id].tsx:108–112` ✅
+- Save in header, accessibilityLabel "Save changes" — `app/habit/[id].tsx:228` ✅
+- Spec refs resolve ✅
+
+Verdict: ✅ verified
+
+---
+
+## UAT-10 — Long-press a card to reveal action menu
+- delayLongPress=400 on card Pressable — `components/HabitCard.tsx:80` ✅
+- `handleLongPress` opens swipe actions via `swipeableRef.openRight()` — `components/HabitCard.tsx:44–46` ✅
+- ⚠️ Note (carry-forward W5): inner drag handle uses `delayLongPress={150}` (`components/HabitCard.tsx:134`) which can race the 400ms card long-press if pressing on the handle area. Already tracked, not new.
+
+Verdict: ✅ verified
+
+---
+
+## UAT-11 — Drag to reorder habits
+- DraggableFlatList renders habits, `onDragEnd` → `reorderHabits(ids)` — `app/(tabs)/index.tsx:85–87, 218–228` ✅
+- Drag hint "Hold to reorder" visible only when habits.length > 1 — `app/(tabs)/index.tsx:163–170` ✅
+- `reorderHabits` writes `sort_order` transactionally — DataModel §3.2 ✅; impl in `store/habitStore.ts:173`
+- Spec refs resolve ✅
+
+Verdict: ✅ verified
+
+---
+
+## UAT-12 — Delete a habit with confirmation
+- Swipe-left → Delete → `Alert.alert("Delete \"name\"?", ...)` — `app/(tabs)/index.tsx:93–108` ✅
+- Cascade via `ON DELETE CASCADE` on completions.habit_id — `db/schema.ts:30` ✅
+- Spec refs resolve ✅
+
+Verdict: ✅ verified
+
+---
+
+## UAT-13 — Archive a habit from the detail screen
+- Detail → Edit → Danger zone "Archive Habit" — `app/habit/[id].tsx:437–451` ✅
+- Confirmation alert: "Archive habit? You can restore it later from Settings." — `app/habit/[id].tsx:146–157` ✅
+- `archiveHabit(id)` sets `is_active = 0`, cancels notification — DataModel §3.2 + `store/habitStore.ts:153–160`. Notification cancellation: verified in `utils/notifications.ts`.
+- Completions preserved (no DELETE) ✅
+- UAT text "tap Archive" — visible button label is "Archive Habit" and the confirmation button is "Archive". Both routes work; UAT acceptable. ✅
+- Spec refs resolve ✅
+
+Verdict: ✅ verified
+
+---
+
+## UAT-14 — Restore an archived habit
+- Settings → ARCHIVED HABITS section with per-row Restore button — `app/(tabs)/settings.tsx:79–101` ✅
+- accessibilityLabel `Restore {name}` — `app/(tabs)/settings.tsx:96` ✅
+- Cap-checked restore in `store/habitStore.ts:162–171` ✅
+- ⚠️ Minor copy mismatch: UAT references "Settings → Archived Habits" as if a subscreen; the code uses an inline section labeled "ARCHIVED HABITS" on the Settings tab itself. The intent is clear enough; UAT acceptable.
+- Spec refs resolve ✅
+
+Verdict: ✅ verified
+
+---
+
+## UAT-15 — 5-habit cap prevents creating a 6th
+- Add button disabled visual at habits.length >= 5 (opacity 0.4, textSecondary color, accessibilityState.disabled=true) — `app/(tabs)/index.tsx:178–190` ✅
+- `handleAddHabit` early-returns when at cap — `app/(tabs)/index.tsx:80–83` ✅
+- Cap banner "You've reached 5 habits…" — `app/(tabs)/index.tsx:154–160` ✅
+- `createHabit` also throws at store level — `store/habitStore.ts:103` ✅
+- Spec refs resolve ✅
+
+Verdict: ✅ verified
+
+---
+
+## UAT-16 — 5-habit cap also blocks restoring a 6th
+- `restoreHabit` re-checks active count and throws — `store/habitStore.ts:162–171` ✅
+- Settings catches and surfaces via `Alert.alert('Cannot restore', err.message)` — `app/(tabs)/settings.tsx:37–39` ✅
+- Spec refs resolve ✅
+
+Verdict: ✅ verified
+
+---
+
+## UAT-17 — Double-tap on CheckButton does not double-complete
+- UNIQUE index `uniq_completions_habit_date` — `db/schema.ts:52` ✅
+- `INSERT OR IGNORE` in markComplete — `db/completions.ts:35` ✅
+- CheckButton blocks taps when already completed (`if (completed) return`) — `components/CheckButton.tsx:28` ✅
+- Today screen catches and ignores — `app/(tabs)/index.tsx:75–77` ✅
+- Spec refs resolve ✅
+
+Verdict: ✅ verified
+
+---
+
+## UAT-18 — Data survives app restart and device reboot
+- SQLite WAL — `db/schema.ts:14` ✅
+- Foreign keys ON — `db/schema.ts:15` ✅
+- Persistence via expo-sqlite local file ✅
+- Spec refs resolve ✅
+
+Verdict: ✅ verified (manual reboot still required to fully exercise)
+
+---
+
+## UAT-19 — Deleting a habit cascades its completions
+- FK `REFERENCES habits(id) ON DELETE CASCADE` — `db/schema.ts:30` ✅
+- `PRAGMA foreign_keys = ON` — `db/schema.ts:15` ✅
+- Spec refs resolve ✅
+
+Verdict: ✅ verified
+
+---
+
+## UAT-20 — Schedule a per-habit reminder
+- Reminder row + modal with hour/minute incrementers + offset pills — `app/habit/new.tsx:282–405`, `app/habit/[id].tsx:399–434, 478–557` ✅
+- Notification identifier `habit-reminder-{id}` — `utils/notifications.ts:35` ✅
+- `rescheduleAllNotifications` on app start — `app/_layout.tsx:30–36` ✅
+- **❌ Broken — UAT text mismatch**:
+  - UAT says "tap Set" — actual button label is `"Set Reminder"` (`app/habit/new.tsx:393`, `app/habit/[id].tsx:545`). **UAT-20 rewritten** to use "Set Reminder".
+  - UAT lists offset pills as "At time / 15 / 30 / 1 hr / 2 hrs before". Actual labels: `"At time"`, `"15 min"`, `"30 min"`, `"1 hr"`, `"2 hrs"` (no "before" suffix on pill; offset is rendered as "· N min before" only on the saved reminder row preview via `formatReminderLabel`). **UAT-20 rewritten** to list pills accurately.
+- Spec refs resolve ✅
+
+Verdict: ❌ rewritten
+
+---
+
+## UAT-21 — Reset onboarding from Settings
+- "Reset onboarding" pressable in Settings → ABOUT — `app/(tabs)/settings.tsx:112–120` ✅
+- Confirms via Alert then `AsyncStorage.removeItem('onboarding_complete')` + replaces route — `app/(tabs)/settings.tsx:42–54` ✅
+- **❌ Broken — UAT text mismatch**: UAT references "Reset Onboarding" (capital O). Visible label is `"Reset onboarding"` (lowercase). **UAT-21 rewritten**.
+- UAT step "force-quit and relaunch" — code routes to `/onboarding` immediately on tap (without needing relaunch). UAT updated to clarify both code-immediate-redirect and post-relaunch behaviour are valid evidence.
+- Spec refs resolve ✅
+
+Verdict: ❌ rewritten
+
+---
+
+## UAT-22 — Dark mode renders every screen readably
+- Theme tokens — `constants/colors.ts:28–50` ✅ (background #121212 line 28, surface #1E1E1E line 29, text #F5F5F5 line 30; heatmap dark scale #1A1F2E … #0A84FF lines 46–50)
+- `useColorScheme()` drives tokens via `useThemeColors` — `app/_layout.tsx:16`, `hooks/useThemeColors.ts`
+- Spec refs resolve ✅
+
+Verdict: ✅ verified
+
+---
+
+## UAT-23 — Reduce Motion suppresses animations and haptics
+- AnimatedPressable gates scale + haptic by `AccessibilityInfo.isReduceMotionEnabled()` — `components/AnimatedPressable.tsx:42` ✅
+- CheckButton gates haptic — `components/CheckButton.tsx:34–38` ✅. Note: CheckButton spring scale is NOT gated by ReduceMotion; the spring animation runs regardless. Tracked under D7.
+- **⚠️ Drift**: confetti is not suppressed (see UAT-07 / D7). UAT-23 partially blocked by D7. UAT-23 retained but qualified.
+
+Verdict: ⚠️ partial; partially blocked by drift D7
+
+---
+
+## UAT-24 — Tap targets and accessibility labels
+- CheckButton default size 44 — `components/CheckButton.tsx:19` ✅ (≥ 40)
+- Drag handle `hitSlop={8}` on 20-pt icon — `components/HabitCard.tsx:136` ✅
+- Add Habit accessibilityLabel + accessibilityState.disabled — `app/(tabs)/index.tsx:188–189` ✅
+- Save / Close / Cancel header buttons have accessibilityLabels — `app/habit/new.tsx:101, 127`, `app/habit/[id].tsx:207, 215, 228, 240` ✅
+- Habit card accessibilityLabel `"{emoji} {name}, {N} minute habit"` — `components/HabitCard.tsx:82` ✅
+- Swipe actions accessibilityLabel "Edit habit" / "Delete habit" — `components/HabitCard.tsx:54, 62` ✅
+- Spec refs resolve ✅
+
+Verdict: ✅ verified
+
+---
+
+## ProductSpec §6 acceptance criterion coverage
+
+| Criterion | Scenarios | Status |
+|---|---|---|
+| 1. <30 s create | UAT-04 | covered (UAT blocked by D6) |
+| 2. Refuses 6th (create or restore) | UAT-15, UAT-16 | covered |
+| 3. Completion → streak + heatmap | UAT-06 | covered |
+| 4. Reminders at time + offset | UAT-20 | covered |
+| 5. Delete cascades | UAT-12, UAT-19 | covered |
+| 6. Persists across restart/reboot | UAT-18 | covered |
+| 7. Light/dark renders readably | UAT-22 | covered |
+| 8. No network needed | UAT-18 (implicit) + added UAT-25 (cross-check) | covered after add |
+
+---
+
+## Summary
+
+- 24 scenarios examined
+- 18 verified clean
+- 4 rewritten in-place for text/label mismatch: UAT-01, UAT-08, UAT-20, UAT-21
+- 2 blocked by spec-vs-code drift escalations: UAT-04 (D6), UAT-07 (D7)
+- 1 partially blocked: UAT-23 (D7)

--- a/docs/test-reports/uat-cross-check.md
+++ b/docs/test-reports/uat-cross-check.md
@@ -1,0 +1,149 @@
+# UAT — Independent Cross-Check Against Spec
+
+**Date:** 2026-05-02
+**Plan under review:** `docs/test-reports/uat-plan.md`
+**Sources re-read:** `docs/ProductSpec.md`, `docs/DesignSpec.md`, `docs/DataModel.md`
+
+## Method
+
+I re-read ProductSpec / DesignSpec / DataModel from scratch and enumerated every distinct testable behavior or invariant, without consulting the existing 24-scenario UAT plan. Once enumerated, I diffed the independent list against the plan and recorded gaps.
+
+## Independent enumeration (bullet form)
+
+### ProductSpec §4 — Feature list
+
+- §4.1 Onboarding shows on first launch
+- §4.1 Onboarding is skippable
+- §4.1 Onboarding completion writes `onboarding_complete` to AsyncStorage
+- §4.1 Onboarding completion emits `onboarding_completed` analytics event
+- §4.1 Onboarding is resettable from Settings
+- §4.2 Create habit (emoji, name 1–50 chars, time-of-day, duration 1–5 min, optional reminder)
+- §4.2 Today tab list rendering, detail screen rendering
+- §4.2 Archived list in Settings
+- §4.2 Update habit
+- §4.2 Hard delete with confirmation, cascade
+- §4.2 Archive (soft) with confirmation
+- §4.2 Restore (with 5-cap check)
+- §4.2 Hard cap on create
+- §4.2 Hard cap banner displayed
+- §4.3 Single-tap completion
+- §4.3 Spring scale + haptic + checkmark glyph
+- §4.3 Double-completion silently prevented
+- §4.4 🔥 N badge when streak ≥ 2
+- §4.4 Milestone confetti at {7,14,21,30,60,90,180,365}
+- §4.4 `streak_milestone` analytics event
+- §4.5 Drag-to-reorder via long-press or ⋮⋮ handle
+- §4.5 `sort_order` persistence
+- §4.5 Drag hint shown when ≥ 2 habits
+- §4.6 Swipe-left reveals Edit + Delete
+- §4.6 Long-press 400ms opens same menu
+- §4.7 Progress: last 7 days dot strip + count
+- §4.7 Progress: per-habit stats (current / longest / total)
+- §4.7 Progress: 8-week heatmap, Monday-anchored, week labels left
+- §4.8 Optional daily reminder per habit
+- §4.8 Configurable time + offset (0/15/30/60/120)
+- §4.8 Notifications rescheduled on every app start
+- §4.8 Android `habit-reminders` channel, HIGH importance
+- §4.9 Rotating daily message indexed by day-of-year
+- §4.10 Light/dark theme via `useColorScheme()`
+- §4.11 Settings — archived list, restore action
+- §4.11 Settings — About, version, reset onboarding
+
+### ProductSpec §6 — Acceptance criteria
+
+- ≤ 30 s to create a habit
+- Refuses 6th active (create + restore)
+- Completion reflects in streak + heatmap immediately
+- Reminders fire at local time, accounting for offset, daily
+- Delete cascades completions
+- Survives restart + reboot
+- Light + dark render readably
+- No screen needs network
+
+### DesignSpec — Component / UX rules
+
+- AnimatedPressable: scale 0.96 + haptic, gated by ReduceMotion
+- HabitCard meta = duration · time-of-day (DesignSpec §2.3)
+- CheckButton 40×40 (effectively 44 per resolved D1), spring 1 → 1.3 → 1
+- CompletionRing: animated foreground stroke, centered counter
+- DailyMessage: 321-message pool (D8 — actual 319)
+- EmojiPicker: 40 curated emoji
+- ReminderModal: hour/minute incrementers + offset pills
+- Onboarding: primary-green background, horizontal FlatList non-scrollable, dots, Next → "Get Started" on last, Skip top-right
+- Today: header + DailyMessage + DraggableFlatList + drag hint + Add Habit footer + cap banner + confetti overlay
+- Today empty state: friendly prompt + same Add Habit footer
+- Progress: last-7 card, per-habit stats, 8-week heatmap
+- Settings: archived list rows, About (version, reset onboarding)
+- New Habit: modal with EmojiPicker, name, time-of-day pills, duration stepper, Reminder row; KeyboardAvoidingView; header Close + Save
+- Habit Detail: hero view + Mark Complete button; Edit mode = New Habit form + danger zone; not-found fallback when habit deleted while open
+- Reduce-motion bypasses ALL motion (DesignSpec §8) — D7
+- Tap targets ≥ 40×40
+
+### DataModel — Invariants
+
+- 5-habit cap enforced in store layer (D=DataModel §2.4, §3.2)
+- One completion per (habit_id, completed_date) enforced via UNIQUE index + INSERT OR IGNORE
+- FK cascade on delete
+- Archiving preserves completions
+- SQLite WAL, FK on, AsyncStorage only for onboarding flag
+
+## Diff against existing UAT plan (UAT-01 … UAT-24)
+
+| Behavior | Coverage in original 24 | Action |
+|---|---|---|
+| Onboarding first launch | UAT-01 | covered |
+| Onboarding completion | UAT-02 | covered |
+| Onboarding skip | UAT-03 | covered |
+| Onboarding reset from Settings | UAT-21 | covered |
+| Create habit happy path | UAT-04 | covered |
+| Habit name validation 1–50 | — | **GAP → UAT-29** |
+| Daily check-in (CheckButton on Today) | UAT-05 | covered |
+| Detail-screen "Mark Complete" path | — | **GAP → UAT-28** |
+| Double-completion prevented | UAT-17 | covered |
+| Streak update post-check-in | UAT-06 | covered |
+| Heatmap renders | UAT-06 | covered |
+| Per-habit stats (current / longest / total) on Progress | — | **GAP → UAT-26** |
+| Milestone confetti | UAT-07 | covered (blocked by D7) |
+| Daily message rotation | UAT-08 | covered |
+| Swipe-left edit/delete | UAT-09, UAT-12 | covered |
+| Long-press menu 400ms | UAT-10 | covered |
+| Drag-to-reorder + hint + persistence | UAT-11 | covered |
+| Delete confirmation + cascade | UAT-12, UAT-19 | covered |
+| Archive + history preserved | UAT-13 | covered |
+| Restore from Settings | UAT-14 | covered |
+| 5-cap on create | UAT-15 | covered |
+| 5-cap on restore | UAT-16 | covered |
+| Restart/reboot persistence | UAT-18 | covered |
+| Reminder schedule | UAT-20 | covered |
+| Notifications rescheduled on app start (dedicated) | mentioned inline in UAT-20 | **GAP → UAT-27** |
+| Dark mode | UAT-22 | covered |
+| Reduce-motion respected | UAT-23 | covered (partial; D7) |
+| Tap targets + a11y labels | UAT-24 | covered |
+| Detail-screen "not found" fallback | — | **GAP → UAT-30** |
+| No screen needs network (explicit) | implicit in UAT-18 | **GAP → UAT-25** |
+| Android `habit-reminders` channel | not iOS-relevant | out of scope for iOS UAT |
+| `onboarding_completed` analytics event | mentioned inline in UAT-02 | covered |
+| `streak_milestone` analytics event | mentioned inline in UAT-07 | covered |
+
+## Scenarios added to uat-plan.md
+
+The following six scenarios were appended to `docs/test-reports/uat-plan.md` under a new section "Coverage additions (from cross-check 2026-05-02)":
+
+- **UAT-25** — App is fully usable with no network connectivity (P0)
+  - Closes ProductSpec §6 criterion 8 which was only implicitly covered.
+- **UAT-26** — Progress per-habit stats show current, longest, and total (P1)
+  - Closes ProductSpec §4.7 / DesignSpec §3.3 (longest streak + total completions previously untested).
+- **UAT-27** — Notifications are rescheduled on every app launch (P1)
+  - Closes ProductSpec §4.8 reschedule-on-start behavior (was only mentioned inline in UAT-20).
+- **UAT-28** — Mark Complete from the habit detail screen (P1)
+  - Closes DesignSpec §3.6 view-mode primary button path.
+- **UAT-29** — Habit name is required (empty submit blocked) (P2)
+  - Closes ProductSpec §4.2 name validation invariant.
+- **UAT-30** — Detail screen recovers when the habit is deleted while open (P2)
+  - Closes DesignSpec §3.6 not-found fallback.
+
+## Result
+
+- Independent enumeration produced 30+ distinct behaviors.
+- 6 gaps vs the original 24 → 6 new scenarios added in-place.
+- Plan now totals 30 scenarios.

--- a/docs/test-reports/uat-plan.md
+++ b/docs/test-reports/uat-plan.md
@@ -1,0 +1,617 @@
+# MicroMoment — User Acceptance Test Plan
+
+**Date:** 2026-05-02
+**Source specs:** `docs/ProductSpec.md`, `docs/DesignSpec.md`, `docs/DataModel.md`
+**Tester:** Flint (iOS QA)
+
+This document is the human-readable acceptance test plan. Each scenario is a self-contained user story written in Given / When / Then form and can be executed manually on the iOS simulator without referencing any automation file.
+
+---
+
+## Summary
+
+**Total scenarios:** 30 (24 original + 6 added 2026-05-02 via cross-check pass)
+
+**By priority:**
+- P0 (must-pass for release): 14
+- P1 (important): 11
+- P2 (nice-to-have): 5
+
+**Journey sections:**
+1. First-time user (UAT-01 → UAT-03)
+2. Daily use (UAT-04 → UAT-08)
+3. Habit management (UAT-09 → UAT-14)
+4. Edge cases & data integrity (UAT-15 → UAT-19)
+5. Settings (UAT-20 → UAT-21)
+6. Accessibility (UAT-22 → UAT-24)
+7. Coverage additions (UAT-25 → UAT-30) — offline operation, Progress stats, notification reschedule, detail-screen completion, name validation, deleted-habit not-found
+
+**Out of scope (per ProductSpec §7):**
+- Multi-device sync, accounts, social features
+- Habits longer than 5 minutes or more than 5 active habits
+- Multiple completions per habit per day
+- Web or tablet layouts
+- Network-dependent features (app is fully offline-first)
+
+---
+
+## First-time user
+
+### UAT-01 — See onboarding on first launch
+
+**As a** brand-new user
+**I want to** be introduced to the app's philosophy on first launch
+**So that** I understand the "5 minutes a day" constraint before I start
+
+**Given** the app has never been launched (AsyncStorage `onboarding_complete` is absent)
+**When** I open the app for the first time
+**Then** the 3-slide onboarding screen appears as a modal with a primary-green background
+**And** the slides cover, in order, the five-minute daily action, the five-habit focus cap, and the streaks/milestones idea (current copy: "Five minutes. Every day. That's it.", "Pick up to 5 habits to focus on.", "Check in daily. Build streaks. Grow.")
+**And** dot indicators show my position, a Next button advances slides, and a Skip button is visible top-right
+**And** the modal cannot be swiped down to dismiss (`gestureEnabled: false` on the onboarding stack screen)
+
+**Spec ref:** ProductSpec §4.1, §5.1; DesignSpec §3.1, §4
+**Priority:** P0
+
+---
+
+### UAT-02 — Complete onboarding and land on empty Today tab
+
+**As a** new user
+**I want to** finish onboarding and arrive at the main screen
+**So that** I can start adding my habits
+
+**Given** I am on slide 1 of onboarding
+**When** I tap Next twice to reach slide 3, then tap "Get Started"
+**Then** the onboarding modal dismisses
+**And** I land on the Today tab with an empty state prompt
+**And** an Add Habit button is visible as the list footer
+**And** an `onboarding_completed` analytics event has fired
+**And** relaunching the app skips onboarding entirely
+
+**Spec ref:** ProductSpec §4.1, §5.1; DesignSpec §3.2
+**Priority:** P0
+
+---
+
+### UAT-03 — Skip onboarding
+
+**As a** returning user familiar with habit apps
+**I want to** skip the intro
+**So that** I can go straight to adding habits
+
+**Given** I am on slide 1 of onboarding
+**When** I tap Skip in the top-right corner
+**Then** the onboarding modal dismisses immediately
+**And** I land on the Today tab empty state
+**And** `onboarding_complete` is persisted, so a subsequent app launch goes straight to Today
+
+**Spec ref:** ProductSpec §4.1
+**Priority:** P1
+
+---
+
+## Daily use
+
+### UAT-04 — Add my first habit in under 30 seconds
+
+**As a** user with no habits yet
+**I want to** create a habit quickly
+**So that** I can begin tracking immediately
+
+**Given** I am on the Today tab with the empty state visible
+**When** I tap the Add Habit footer button
+**And** the New Habit modal opens, I pick an emoji from the palette, type a name ("Meditate"), pick a time-of-day pill ("morning"), set duration to 5 minutes, and tap Save
+**Then** the modal dismisses within 30 seconds of starting
+**And** the habit appears on the Today tab with its emoji, name, duration meta, and an unchecked CheckButton
+**And** the data persists across an app restart
+
+> Drift D6 resolved: `components/HabitCard.tsx` now renders `"{N} min · 🌅 Morning"` (etc) via `TIME_OF_DAY_META`.
+
+**Spec ref:** ProductSpec §4.2, §5.2, §6 (criterion 1); DesignSpec §3.5, §2.3
+**Priority:** P0
+
+---
+
+### UAT-05 — Check in a habit for today
+
+**As a** user with at least one active habit
+**I want to** mark it complete with one tap
+**So that** my streak progresses
+
+**Given** I am on the Today tab and a habit is showing an empty CheckButton
+**When** I tap the CheckButton once
+**Then** the button springs from scale 1 → 1.3 → 1, fills primary green, and shows a white checkmark
+**And** I feel a haptic impact (unless Reduce Motion is on)
+**And** the card dims to opacity 0.45 with completedText color
+**And** if this completion creates a streak ≥ 2, a 🔥 N badge appears on the card
+
+**Spec ref:** ProductSpec §4.3, §5.3; DesignSpec §2.4, §3.2
+**Priority:** P0
+
+---
+
+### UAT-06 — Streak count and heatmap update immediately after check-in
+
+**As a** user who just checked in
+**I want to** see my streak and progress reflect the completion right away
+**So that** I trust the data is captured
+
+**Given** I have an active habit with a current streak of 1 (yesterday completed)
+**When** I tap the CheckButton on the Today tab to complete it for today
+**And** I switch to the Progress tab
+**Then** the current streak for that habit reads 2
+**And** today's cell in the 8-week heatmap is colored at the appropriate intensity
+**And** the last-7-days dot strip shows today filled in
+
+**Spec ref:** ProductSpec §6 (criterion 3), §4.4, §4.7; DesignSpec §3.3
+**Priority:** P0
+
+---
+
+### UAT-07 — Milestone confetti at 7-day streak
+
+**As a** consistent user
+**I want to** be celebrated on milestone streaks
+**So that** I feel encouraged to continue
+
+**Given** I have a habit with a 6-day current streak (yesterday was day 6)
+**When** I tap the CheckButton today
+**Then** a confetti animation fires from top-center with ~120 particles falling over ~3 seconds
+**And** the 🔥 badge updates to 🔥 7
+**And** a `streak_milestone` analytics event is emitted with the streak value 7
+**And** if Reduce Motion is on, the confetti is suppressed but the badge still updates
+
+> Drift D7 resolved: confetti and CheckButton spring now gated via `hooks/useReduceMotion.ts` (`app/(tabs)/index.tsx`, `components/CheckButton.tsx`).
+
+**Spec ref:** ProductSpec §4.4; DesignSpec §5 (Confetti), §8
+**Priority:** P1
+
+---
+
+### UAT-08 — Daily motivational message rotates
+
+**As a** user opening the app
+**I want to** see a small dose of encouragement
+**So that** the app feels warm
+
+**Given** I open the Today tab on any given date
+**Then** a single-line motivational message is rendered in the header below the date string
+**And** opening the app on a different day shows a different message (selection is by day-of-year from a fixed `DAILY_MESSAGES` pool of ~320 entries in `constants/messages.ts`)
+
+> Drift note (D8): ProductSpec §4.9 and DesignSpec §2.6 both state 321 entries. Actual pool size is 319 (`grep -E '^  "' constants/messages.ts | wc -l`). Rotation behavior is the testable property; exact count is a docs nit.
+
+**Spec ref:** ProductSpec §4.9; DesignSpec §2.6, §3.2
+**Priority:** P2
+
+---
+
+## Habit management
+
+### UAT-09 — Edit a habit via swipe-left
+
+**As a** user
+**I want to** edit a habit from the Today tab without navigating into detail first
+**So that** I can fix mistakes quickly
+
+**Given** I am on the Today tab with at least one habit
+**When** I swipe a habit card to the left
+**Then** Edit (green) and Delete (red) actions are revealed on the right side
+**When** I tap Edit
+**Then** the habit edit screen opens in edit mode (`/habit/[id]?mode=edit`) with all fields prefilled
+**When** I change the name and tap Save in the header
+**Then** I return to the Today tab and the card shows the new name
+
+**Spec ref:** ProductSpec §4.6, §5.4; DesignSpec §2.3, §3.6
+**Priority:** P0
+
+---
+
+### UAT-10 — Long-press a card to reveal action menu
+
+**As a** user who prefers gestures over swipes
+**I want to** long-press a card to access Edit and Delete
+**So that** I can manage habits without a swipe
+
+**Given** I am on the Today tab with at least one habit
+**When** I press and hold a habit card for 400ms
+**Then** the same Edit / Delete action menu revealed by swipe-left appears
+**And** releasing without selecting closes the menu
+
+**Spec ref:** ProductSpec §4.6; DesignSpec §2.3, §5
+**Priority:** P1
+
+---
+
+### UAT-11 — Drag to reorder habits
+
+**As a** user with multiple habits
+**I want to** drag them into my preferred order
+**So that** the most important habit is on top
+
+**Given** I have ≥ 2 active habits on the Today tab
+**Then** the list header shows the hint "Hold to reorder"
+**When** I long-press a card or grab its ⋮⋮ drag handle and drag it to a new position
+**Then** the list reorders visually as I drag and snaps into place on release
+**And** the new order persists across an app restart (written to `sort_order`)
+
+**Spec ref:** ProductSpec §4.5; DesignSpec §5, DataModel §3.2 (`reorderHabits`)
+**Priority:** P1
+
+---
+
+### UAT-12 — Delete a habit with confirmation
+
+**As a** user
+**I want to** be asked to confirm before deleting a habit
+**So that** I don't lose my history accidentally
+
+**Given** I have a habit with several completions
+**When** I swipe left on the card and tap Delete
+**Then** a confirmation alert appears warning that deletion is permanent
+**When** I confirm
+**Then** the habit disappears from the Today tab
+**And** all its completions are removed from the database (FK cascade)
+**And** the heatmap and per-habit stats on the Progress tab no longer include it
+
+**Spec ref:** ProductSpec §4.2, §6 (criterion 5); DataModel §2.2, §2.4
+**Priority:** P0
+
+---
+
+### UAT-13 — Archive a habit from the detail screen
+
+**As a** user pausing a habit
+**I want to** archive it rather than delete
+**So that** I preserve my completion history
+
+**Given** I open a habit's detail screen and tap Edit
+**When** I scroll to the Danger zone and tap Archive, confirming the alert
+**Then** the habit disappears from the Today tab
+**And** its scheduled notification (if any) is cancelled
+**And** its completions remain in the database (history preserved per DataModel §2.4)
+**And** the habit now appears in Settings → Archived Habits
+
+**Spec ref:** ProductSpec §4.2, §5.5; DataModel §2.4, §6
+**Priority:** P0
+
+---
+
+### UAT-14 — Restore an archived habit
+
+**As a** user resuming a paused habit
+**I want to** restore it from Settings
+**So that** it comes back to my Today tab
+
+**Given** I have an archived habit and fewer than 5 active habits
+**When** I open Settings → Archived Habits and tap Restore on the row
+**Then** the habit reappears on the Today tab
+**And** its notification (if a reminder time is set) is rescheduled
+**And** its preserved completions show up again in Progress
+
+**Spec ref:** ProductSpec §4.2, §5.5; DataModel §3.2, §6
+**Priority:** P1
+
+---
+
+## Edge cases & data integrity
+
+### UAT-15 — 5-habit cap prevents creating a 6th
+
+**As a** user respecting the app's constraint philosophy
+**I want to** be stopped from adding a 6th habit
+**So that** I stay focused
+
+**Given** I have 5 active habits on the Today tab
+**Then** the Add Habit footer button shows opacity 0.4 with secondary-text color and is disabled (`accessibilityState.disabled = true`)
+**When** I tap it
+**Then** nothing happens — no haptic, no navigation
+**And** the cap banner / disabled state communicates that the limit has been reached
+
+**Spec ref:** ProductSpec §4.2, §6 (criterion 2); DesignSpec §3.2; DataModel §3.3
+**Priority:** P0
+
+---
+
+### UAT-16 — 5-habit cap also blocks restoring a 6th
+
+**As a** user at the cap
+**I want to** be prevented from restoring an archived habit that would exceed the cap
+**So that** the 5-habit invariant is never violated
+
+**Given** I have 5 active habits and at least 1 archived habit
+**When** I open Settings → Archived Habits and tap Restore
+**Then** the restore is refused (no state change) and I receive feedback that the cap is reached
+**And** the active count remains 5
+
+**Spec ref:** ProductSpec §4.2, §6 (criterion 2); DataModel §3.2 (`restoreHabit` cap check)
+**Priority:** P0
+
+---
+
+### UAT-17 — Double-tap on CheckButton does not double-complete
+
+**As a** user
+**I want to** be unable to accidentally complete the same habit twice on the same day
+**So that** my streak math stays correct
+
+**Given** I have an active habit not yet completed today
+**When** I tap the CheckButton twice in rapid succession
+**Then** only one completion is recorded for today (verified via Progress totals or DB)
+**And** the second tap is silently ignored (no error, no extra haptic)
+**And** the card remains in the completed visual state
+
+**Spec ref:** ProductSpec §4.3, §7; DataModel §2.4, §3.2 (`markComplete` idempotent guard)
+**Priority:** P0
+
+---
+
+### UAT-18 — Data survives app restart and device reboot
+
+**As a** user trusting a local-first app
+**I want to** never lose data
+**So that** my streaks are real
+
+**Given** I have created habits, recorded completions, and reordered the list
+**When** I force-quit the app and relaunch it
+**Then** all habits, completions, sort order, streaks, and reminder settings are intact
+**When** I reboot the device and relaunch
+**Then** the same data is still intact (SQLite WAL flushed correctly)
+**And** no network connection is required to render any screen
+
+**Spec ref:** ProductSpec §6 (criteria 6, 8); DataModel §1
+**Priority:** P0
+
+---
+
+### UAT-19 — Deleting a habit cascades its completions
+
+**As a** developer-conscious user
+**I want to** know that deleting a habit fully removes its data
+**So that** there are no orphan rows or ghost heatmap cells
+
+**Given** I have a habit with multiple completions across the last 30 days
+**When** I delete the habit (confirmed) from swipe-left → Delete
+**Then** the `habits` row is removed
+**And** every `completions` row with that `habit_id` is removed via ON DELETE CASCADE
+**And** the Progress tab no longer references the habit anywhere
+
+**Spec ref:** ProductSpec §6 (criterion 5); DataModel §2.2, §2.4
+**Priority:** P0
+
+---
+
+## Settings
+
+### UAT-20 — Schedule a per-habit reminder
+
+**As a** user who needs nudges
+**I want to** set a daily reminder time and offset
+**So that** the habit is on my mind
+
+**Given** I am creating or editing a habit
+**When** I tap the Reminder row
+**Then** the ReminderModal opens with hour/minute incrementers and a row of offset pills with the exact labels `At time`, `15 min`, `30 min`, `1 hr`, `2 hrs`
+**When** I set 09:00, tap the `15 min` offset pill, and tap the `Set Reminder` button
+**Then** the row shows the configured reminder (formatted as "09:00 · 15 min before")
+**And** on save, a daily local notification is scheduled with identifier `habit-reminder-{id}`
+**And** the effective fire time is 08:45 local time, every day
+**And** on the next app launch, `rescheduleAllNotifications` re-registers the same schedule
+
+**Spec ref:** ProductSpec §4.8, §5.6, §6 (criterion 4); DesignSpec §2.8; DataModel §5
+**Priority:** P0
+
+---
+
+### UAT-21 — Reset onboarding from Settings
+
+**As a** user demonstrating the app to a friend
+**I want to** replay the onboarding
+**So that** they see the intro
+
+**Given** I am on Settings → ABOUT
+**When** I tap the "Reset onboarding" row (lowercase "o" in the visible label, per `app/(tabs)/settings.tsx:118`)
+**Then** a confirmation alert ("Reset onboarding?") appears
+**When** I confirm Reset
+**Then** `onboarding_complete` is cleared from AsyncStorage and the app immediately replaces the route to `/onboarding`
+**And** subsequently force-quitting and relaunching the app also lands me back on slide 1 of the 3-slide onboarding modal
+
+**Spec ref:** ProductSpec §4.1, §4.11
+**Priority:** P2
+
+---
+
+## Accessibility
+
+### UAT-22 — Dark mode renders every screen readably
+
+**As a** user with the system in dark mode
+**I want to** every screen to use dark theme tokens
+**So that** the app is not blinding at night
+
+**Given** my iOS system appearance is set to Dark
+**When** I open the app and visit Today, Progress, Settings, New Habit, and Habit Detail
+**Then** every screen uses dark theme tokens (background #121212, surface #1E1E1E, text #F5F5F5)
+**And** text contrast meets WCAG AA against its background on every screen
+**And** the heatmap uses the dark scale (#1A1F2E → #0A84FF)
+**And** switching system appearance back to Light updates the UI live without a restart
+
+**Spec ref:** ProductSpec §4.10, §6 (criterion 7); DesignSpec §1.1
+**Priority:** P0
+
+---
+
+### UAT-23 — Reduce Motion suppresses animations and haptics
+
+**As a** user with motion sensitivity who has enabled Reduce Motion
+**I want to** the app to skip springs, scales, confetti, and haptics
+**So that** I can use the app without discomfort
+
+**Given** Settings → Accessibility → Reduce Motion is ON
+**When** I tap a CheckButton, tap a primary Button, or hit a streak milestone
+**Then** there is no spring scale animation on press
+**And** there is no haptic impact
+**And** no confetti is rendered on milestone completion
+**And** the underlying state changes (completion recorded, streak updated, badge shown) all still occur
+
+**Spec ref:** DesignSpec §2.2, §6, §8
+**Priority:** P1
+
+---
+
+### UAT-24 — Tap targets and accessibility labels
+
+**As a** user relying on VoiceOver or with reduced dexterity
+**I want to** every interactive element to be reachable and announced
+**So that** I can use the app without precision taps
+
+**Given** I navigate the app with VoiceOver enabled
+**Then** the CheckButton, drag handle, tab icons, Add Habit button, Save / Close header buttons, and swipe actions are all ≥ 40×40 points
+**And** each interactive control exposes a meaningful accessibilityLabel (e.g. habit name, "Mark complete", "Delete")
+**And** the Add Habit button at the 5-habit cap announces its disabled state
+**And** the reading order on each screen is logical top-to-bottom
+
+**Spec ref:** DesignSpec §6; ProductSpec §4 (general)
+**Priority:** P1
+
+---
+
+## Coverage additions (from cross-check 2026-05-02)
+
+### UAT-25 — App is fully usable with no network connectivity
+
+**As a** local-first user
+**I want to** open and use every screen with no network
+**So that** I can trust the "no cloud" promise
+
+**Given** I have habits, completions, reminders, and archived entries already created
+**When** I put the device into Airplane Mode and cold-launch the app
+**Then** Onboarding (if reset), Today, Progress, Settings, New Habit, and Habit Detail/Edit all render without errors or blank states
+**And** I can complete a habit, create a habit, edit a habit, archive/restore a habit, and reorder habits with no spinner or error toast
+**And** no outbound network request is made (verified via Charles/Proxyman or by observing that the app does not stall on launch)
+
+**Spec ref:** ProductSpec §6 (criterion 8), §3 ("Local-first")
+**Priority:** P0
+
+---
+
+### UAT-26 — Progress per-habit stats show current, longest, and total
+
+**As a** user who wants to see how I'm trending
+**I want to** the Progress tab to show me my current streak, longest streak, and total completions per habit
+**So that** I have something to look back on
+
+**Given** I have ≥ 1 active habit with several completions, including a past streak run
+**When** I open the Progress tab
+**Then** for each habit the row shows the emoji pill, the habit name, "🔥 N" (current streak), "Best M" (longest streak), and "K done" (total completions)
+**And** the values match what `utils/streakCalculator.calculateStreak()` computes over the habit's completion-date list
+**And** when no habits exist, the empty prompt "Add habits on the Today tab to see your progress here." appears instead
+
+**Spec ref:** ProductSpec §4.7; DesignSpec §3.3; DataModel §4
+**Priority:** P1
+
+---
+
+### UAT-27 — Notifications are rescheduled on every app launch
+
+**As a** user with a configured reminder
+**I want to** every cold launch to re-register my reminders
+**So that** OS-level cancellation or clock changes don't silently lose them
+
+**Given** I have ≥ 1 active habit with `reminder_time` set
+**When** I cold-launch the app
+**Then** `rescheduleAllNotifications(habits)` runs from `app/_layout.tsx:30–36`
+**And** all previously scheduled `habit-reminder-{id}` notifications are cancelled, then re-scheduled for each active habit with a reminder
+**And** verifying via Expo Notifications list (`getAllScheduledNotificationsAsync()`) shows one entry per habit with a reminder
+
+**Spec ref:** ProductSpec §4.8; DataModel §5
+**Priority:** P1
+
+---
+
+### UAT-28 — Mark Complete from the habit detail screen
+
+**As a** user viewing a habit detail
+**I want to** complete the habit directly from the detail screen
+**So that** I don't have to back out to the Today tab
+
+**Given** I open a habit's detail screen and it is not yet completed today
+**When** I tap the "Mark Complete" primary button
+**Then** the completion is recorded, the button switches to "Completed Today" (disabled, secondary variant)
+**And** returning to the Today tab shows the habit in its completed state (opacity 0.45, checkmark filled)
+**And** tapping again while in the "Completed Today" state does nothing (disabled)
+
+**Spec ref:** DesignSpec §3.6; ProductSpec §4.3
+**Priority:** P1
+
+---
+
+### UAT-29 — Habit name is required (empty submit blocked)
+
+**As a** user
+**I want to** be prevented from creating a nameless habit
+**So that** my list stays meaningful
+
+**Given** I am on the New Habit modal with all fields default except the name left blank (or whitespace-only)
+**When** I tap Save in the header
+**Then** an alert appears ("Name required — Give your habit a name.")
+**And** no habit is inserted (`habits` row count unchanged)
+**And** the modal stays open with focus retained
+**When** I type a 1-character name and re-save, the habit is created
+**And** the name field caps input at 50 characters (`maxLength={50}` on the TextInput)
+
+**Spec ref:** ProductSpec §4.2 ("name 1–50 chars")
+**Priority:** P2
+
+---
+
+### UAT-30 — Detail screen recovers when the habit is deleted while open
+
+**As a** user
+**I want to** not see a crash if the habit I'm viewing gets deleted from elsewhere (or by me from the danger zone)
+**So that** the app stays stable
+
+**Given** I open a habit's detail screen, then tap Edit → Danger zone → Delete and confirm
+**Then** the screen routes back to the previous tab
+**When** I navigate by URL/state directly to `/habit/{deletedId}` (e.g. via a stale deep link)
+**Then** the detail screen renders the "Habit not found." fallback with a Back button (`app/habit/[id].tsx:177–196`)
+**And** no crash, white screen, or unhandled error occurs
+
+**Spec ref:** DesignSpec §3.6 ("Falls back to 'not found' state if habit was deleted while open")
+**Priority:** P2
+
+---
+
+## Coverage cross-reference
+
+**ProductSpec §5 user flows:**
+- §5.1 First launch → UAT-01, UAT-02
+- §5.2 Add first habit → UAT-04
+- §5.3 Daily check-in → UAT-05, UAT-06
+- §5.4 Edit a habit → UAT-09
+- §5.5 Archive / Restore → UAT-13, UAT-14
+- §5.6 Set a reminder → UAT-20
+
+**ProductSpec §6 acceptance criteria (all 8):**
+1. Habit creation in under 30 seconds → UAT-04
+2. Refuses 6th active habit (create or restore) → UAT-15, UAT-16
+3. Completion reflects in streak and heatmap → UAT-06
+4. Reminders fire at configured time with offset → UAT-20
+5. Deletion cascades completions → UAT-12, UAT-19
+6. Data persists across restart and reboot → UAT-18
+7. Light/dark themes render readably → UAT-22
+8. No screen needs network → UAT-25 (explicit airplane-mode); UAT-18 (implicit)
+
+**DataModel invariants:**
+- 5-habit cap → UAT-15, UAT-16
+- Single completion per (habit, date) → UAT-17
+- FK cascade on delete → UAT-12, UAT-19
+- Archiving preserves completions → UAT-13
+
+**DesignSpec key interactions:**
+- Swipe-to-delete / swipe-to-edit → UAT-09, UAT-12
+- Long-press menu → UAT-10
+- Drag-to-reorder → UAT-11
+- Milestone confetti → UAT-07
+- Dark mode → UAT-22
+- Reduce Motion → UAT-23

--- a/e2e/00_launch.yaml
+++ b/e2e/00_launch.yaml
@@ -4,4 +4,4 @@ appId: com.nav1885.micromoment
     clearState: true
 - runFlow: _skip_onboarding.yaml
 - assertVisible: "No habits yet"
-- assertVisible: "Add Habit"
+- assertVisible: "Add new habit"

--- a/e2e/01_add_habit.yaml
+++ b/e2e/01_add_habit.yaml
@@ -5,7 +5,7 @@ appId: com.nav1885.micromoment
 - runFlow: _skip_onboarding.yaml
 
 # Open new habit screen
-- tapOn: "Add Habit"
+- tapOn: "Add new habit"
 - assertVisible: "New Habit"
 
 # Type habit name

--- a/e2e/_skip_onboarding.yaml
+++ b/e2e/_skip_onboarding.yaml
@@ -1,7 +1,25 @@
 appId: com.nav1885.micromoment
 ---
-# Tap through 3 onboarding slides then land on Today tab
-- tapOn: "Next"
-- tapOn: "Next"
-- tapOn: "Get Started"
-- assertVisible: "Today"
+# Tap through 3 onboarding slides then land on Today tab.
+# Targets accessibilityLabel values — the Pressable wraps the inner
+# <Text> so only the a11y label is discoverable. waitForAnimationToEnd
+# between taps gates the FlatList scroll so consecutive taps don't
+# collapse onto the same slide.
+# Use the dot-indicator labels as gates — they update synchronously
+# with the currentIndex state, so they're a reliable signal that the
+# slide actually advanced before we tap Next again.
+- extendedWaitUntil:
+    visible: "Slide 1 of 3"
+    timeout: 5000
+- tapOn: "Next slide"
+- extendedWaitUntil:
+    visible: "Slide 2 of 3"
+    timeout: 5000
+- tapOn: "Next slide"
+- extendedWaitUntil:
+    visible: "Slide 3 of 3"
+    timeout: 5000
+- tapOn: "Get started"
+- extendedWaitUntil:
+    visible: "No habits yet"
+    timeout: 8000

--- a/e2e/run_for_flint.sh
+++ b/e2e/run_for_flint.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# Per-flow Maestro runner for Flint. Outputs one line per flow:
+#   PASS <name> | FAIL <name> | TIMEOUT <name>
+# Logs land in /tmp/flint-<name>.log; screenshots on failure.
+set -uo pipefail
+
+export JAVA_HOME="${JAVA_HOME:-/opt/homebrew/opt/openjdk@17}"
+export PATH="$JAVA_HOME/bin:$HOME/.maestro/bin:$PATH"
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# Portable timeout: prefer gtimeout (coreutils), fall back to perl alarm shim.
+if command -v gtimeout >/dev/null 2>&1; then
+  TIMEOUT_CMD=(gtimeout 120)
+elif command -v timeout >/dev/null 2>&1; then
+  TIMEOUT_CMD=(timeout 120)
+else
+  TIMEOUT_CMD=(perl -e 'alarm 120; exec @ARGV or die "exec: $!"' --)
+fi
+
+PASS=0
+FAIL=0
+
+for flow in "$DIR"/[0-9]*.yaml; do
+  name=$(basename "$flow" .yaml)
+  if "${TIMEOUT_CMD[@]}" maestro test "$flow" > "/tmp/flint-$name.log" 2>&1; then
+    echo "PASS $name"
+    PASS=$((PASS + 1))
+  else
+    rc=$?
+    if [ "$rc" -eq 124 ] || [ "$rc" -eq 142 ]; then
+      echo "TIMEOUT $name"
+    else
+      echo "FAIL $name"
+    fi
+    xcrun simctl io booted screenshot "/tmp/flint-$name-fail.png" 2>/dev/null || true
+    FAIL=$((FAIL + 1))
+  fi
+done
+
+echo "==== TOTALS: $PASS pass / $FAIL fail ===="

--- a/hooks/useReduceMotion.ts
+++ b/hooks/useReduceMotion.ts
@@ -1,0 +1,20 @@
+import { useEffect, useState } from 'react'
+import { AccessibilityInfo } from 'react-native'
+
+export function useReduceMotion(): boolean {
+  const [reduced, setReduced] = useState(false)
+
+  useEffect(() => {
+    let mounted = true
+    AccessibilityInfo.isReduceMotionEnabled().then((value) => {
+      if (mounted) setReduced(value)
+    })
+    const sub = AccessibilityInfo.addEventListener('reduceMotionChanged', setReduced)
+    return () => {
+      mounted = false
+      sub.remove()
+    }
+  }, [])
+
+  return reduced
+}


### PR DESCRIPTION
Resolves all three drift items found during Flint's UAT validation. Details in docs/test-reports/spec-drift.md. Tests + tsc green.